### PR TITLE
Typo fix in french

### DIFF
--- a/locales/fr/calendar.json
+++ b/locales/fr/calendar.json
@@ -1,7 +1,7 @@
 {
   "date": "Date",
   "time": "Heure",
-  "event": "Grands Prix de Formule Un",
+  "event": "Grands Prix de Formule 1",
   "notice": {
     "text": "Ci-dessous, les 8 premières courses du calendrier révisé. Horaires et courses additionnelles en attente de confirmation.",
     "link": "En savoir plus"

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -1,12 +1,12 @@
 {
   "title": "Calendrier F1",
   "subtitle": "Courses, Qualifications & Essais Libres",
-  "meta":{
-    "description": "Calendrier Fromule Un pour la saison {{year}} avec tous les Grands Prix, essais libres &amp; qualificatifs. Activer les rappels. Tous les fuseaux horaires. Télécharger ou s'abonner.",
-    "keywords": "F1, formule un, horaires des courses, courses, rappel, alertes, grands prix, grand prix, calendrier, dates, heures de départ, qualifications, essais, Londres, Europe, {{year}}"
+  "meta": {
+    "description": "Calendrier Formule 1 pour la saison {{year}} avec tous les Grands Prix, essais libres &amp; qualificatifs. Activer les rappels. Tous les fuseaux horaires. Télécharger ou s'abonner.",
+    "keywords": "F1, formule 1, horaires des courses, courses, rappel, alertes, grands prix, grand prix, calendrier, dates, heures de départ, qualifications, essais, Londres, Europe, {{year}}"
   },
   "options": {
-    "calendar": "Ajouter ces dates et horaires de grand Prix à votre calendrier.",
+    "calendar": "Ajouter ces dates et horaires de Grand Prix à votre calendrier.",
     "timezonePicker": {
       "showing": "Montrer les horaires pour",
       "pick": "Choisissez un fuseau horaire...",
@@ -16,18 +16,18 @@
   "contribute": "Contribuer",
   "cookies": {
     "title": "Ce site utilise des cookies pour améliorer l'expérience utilisateur.",
-    "button": "Super!"
+    "button": "Super !"
   },
   "javascript": "F1 Calendar fonctionne mieux lorsque Javascript est activé.",
   "footer": {
     "coffee": "Supportez F1 Calendar, offrez-nous un café.",
     "twitter": "Nous sommes sur Twitter.",
     "github": "Logiciel libre en accès sur GitHub.",
-    "issue": "Vous avez trouvé une erreur? Dites-le nous.",
+    "issue": "Vous avez trouvé une erreur ? Dites-le nous.",
     "links": {
-      "wereOn": "Nous somme sur",
+      "wereOn": "Nous sommes sur",
       "openSourcedOn": "Logiciel libre sur",
-      "spottedIssue": "Vous avez trouvé une erreur?",
+      "spottedIssue": "Vous avez trouvé une erreur ?",
       "spottedReport": "Dites-le nous."
     }
   }

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -1,6 +1,6 @@
 {
   "title": "Calendrier F1",
-  "subtitle": "Courses, Qualifications & Essais Libres",
+  "subtitle": "Courses, Qualifications &amp; Essais Libres",
   "meta": {
     "description": "Calendrier Formule 1 pour la saison {{year}} avec tous les Grands Prix, essais libres &amp; qualificatifs. Activer les rappels. Tous les fuseaux horaires. Télécharger ou s'abonner.",
     "keywords": "F1, formule 1, horaires des courses, courses, rappel, alertes, grands prix, grand prix, calendrier, dates, heures de départ, qualifications, essais, Londres, Europe, {{year}}"
@@ -16,18 +16,18 @@
   "contribute": "Contribuer",
   "cookies": {
     "title": "Ce site utilise des cookies pour améliorer l'expérience utilisateur.",
-    "button": "Super !"
+    "button": "Super&nbsp!"
   },
   "javascript": "F1 Calendar fonctionne mieux lorsque Javascript est activé.",
   "footer": {
     "coffee": "Supportez F1 Calendar, offrez-nous un café.",
     "twitter": "Nous sommes sur Twitter.",
     "github": "Logiciel libre en accès sur GitHub.",
-    "issue": "Vous avez trouvé une erreur ? Dites-le nous.",
+    "issue": "Vous avez trouvé une erreur&nbsp? Dites-le nous.",
     "links": {
       "wereOn": "Nous sommes sur",
       "openSourcedOn": "Logiciel libre sur",
-      "spottedIssue": "Vous avez trouvé une erreur ?",
+      "spottedIssue": "Vous avez trouvé une erreur&nbsp?",
       "spottedReport": "Dites-le nous."
     }
   }

--- a/locales/fr/generate.json
+++ b/locales/fr/generate.json
@@ -1,7 +1,7 @@
 {
   "form": {
     "title": "Génerer un calendrier",
-    "description": "Choisissez quelles séances des weekends de Grand Prix vous souhaitez ajouter à votre calendrier:",
+    "description": "Choisissez quelles séances des weekends de Grand Prix vous souhaitez ajouter à votre calendrier :",
     "fp1": "Essais libres 1",
     "fp2": "Essais libres 2",
     "fp3": "Essais libres 3",
@@ -22,7 +22,7 @@
     "gcalDescription": "Pour ajouter le calendrier, copiez-collez ce lien dans Google Calendar",
     "gcalDescriptionLink": "Instructions détaillées",
     "icsTitle": "Télécharger le fichier ICS",
-    "icsDescription": "Calendrier hors connection (.ics) pour les calendriers qui ne supportent pas les mises à jour.",
+    "icsDescription": "Calendrier hors connexion (.ics) pour les calendriers qui ne supportent pas les mises à jour.",
     "icsButton": "Télécharger"
   }
 }

--- a/locales/fr/generate.json
+++ b/locales/fr/generate.json
@@ -1,7 +1,7 @@
 {
   "form": {
     "title": "Génerer un calendrier",
-    "description": "Choisissez quelles séances des weekends de Grand Prix vous souhaitez ajouter à votre calendrier :",
+    "description": "Choisissez quelles séances des weekends de Grand Prix vous souhaitez ajouter à votre calendrier&nbsp:",
     "fp1": "Essais libres 1",
     "fp2": "Essais libres 2",
     "fp3": "Essais libres 3",


### PR DESCRIPTION
Some typo fixes in French.
- Nobody uses "Formule Un" in French
- In french, there are non-breakable spaces in front of characters `:` and `?`
- Some other spelling typos.