### PR TITLE
Add small fix for TBC content in localization string

### DIFF
--- a/components/Race.module.scss
+++ b/components/Race.module.scss
@@ -68,6 +68,7 @@
   @extend %badge;
   background: #999;
   color: #000;
+  width: max-content;
 }
 
 .tickets {


### PR DESCRIPTION
Add small fix for TBC content in localization string.
In some languages, this content block is not displayed properly.
Maybe there is a better solution for this.