### PR TITLE
Adding Dutch localization

### DIFF
--- a/locales/nl/calendar.json
+++ b/locales/nl/calendar.json
@@ -1,0 +1,49 @@
+{
+  "date": "Datum",
+  "time": "Tijd",
+  "event": "Formule 1 Grote Prijs Evenementen",
+  "notice": {
+    "text": "Onderstaand zijn de eerste 8 races van de herziene kalender. De tijden moeten nog beslist worden alsook bijkomende races.",
+    "link": "Meer informatie"
+  },
+  "badges": {
+    "tbc": "TB",
+    "tbc_title": "Te beslissen",
+    "tickets": "Ticketten",
+    "canceled": "Geannuleerd",
+    "next": "VOLGENDE"
+  },
+  "schedule": {
+    "fp1": "Vrije Training 1",
+    "fp2": "Vrije Training 2",
+    "fp3": "Vrije Training 3",
+    "qualifying": "Kwalificatie",
+    "race": "Race"
+  },
+  "races": {
+    "austrian-grand-prix": "Grote Prijs van Oostenrijk",
+    "steiermark-grand-prix": "Grote Prijs van Stiermarken (Oostenrijk)",
+    "hungary-grand-prix": "Grote Prijs van Hongarije",
+    "british-grand-prix": "Grote Prijs van Groot-Brittannië",
+    "anniversary-british-grand-prix": "Grote Prijs 70 jaar jubileum (Groot-Brittannië)",
+    "spanish-grand-prix": "Grote Prijs van Spanje",
+    "belgian-grand-prix": "Grote Prijs van België",
+    "italian-grand-prix": "Grote Prijs van Italië",
+    "australian-grand-prix": "Grote Prijs van Australië",
+    "bahrain-grand-prix": "Grote Prijs van Bahrein",
+    "vietnamese-grand-prix": "Grote Prijs van Vietnam",
+    "china-grand-prix": "Grote Prijs van China",
+    "dutch-grand-prix": "Grote Prijs van Nederland",
+    "monoco-grand-prix": "Grote Prijs van Monaco",
+    "azerbaijan-grand-prix": "Grote Prijs van Azerbeidzjan",
+    "canadian-grand-prix": "Grote Prijs van Canada",
+    "french-grand-prix": "Grote Prijs van Frankrijk",
+    "singapore-grand-prix": "Grote Prijs van Singapore",
+    "russian-grand-prix": "Grote Prijs van Rusland",
+    "japanese-grand-prix": "Grote Prijs van Japan",
+    "us-grand-prix": "Grote Prijs van de Verenigde Staten van Amerika",
+    "mexico-grand-prix": "Grote Prijs van Mexico-Stad",
+    "brazilian-grand-prix": "Grote Prijs van Brazilië",
+    "abu-dhabi-grand-prix": "Grote Prijs van Abu Dhabi"
+  }
+}

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -1,0 +1,35 @@
+{
+  "title": "F1 Kalender",
+  "subtitle": "Race, Kwalificatie & Vrije Training Sessies",
+  "meta":{
+    "description": "Formule 1 Kalender voor seizoen {{year}} met alle F1 race-, kwalificatie- en vrije training sessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+    "keywords": "F1, formule 1, formule één, race tijden, races, herinnering, alarm, waarschuwing, grote prijzen, grote prijs, kalender, datums, starttijden, kwalificatie, oefening, vrije training, Londen, Europa, {{year}}"
+  },
+  "options": {
+    "calendar": "Voeg deze race datums en starttijden toe aan je kalender",
+    "timezonePicker": {
+      "showing": "Starttijden voor",
+      "pick": "Kies een tijdzone...",
+      "button": "Gedaan"
+    }
+  },
+  "contribute": "Help ons",
+  "cookies": {
+    "title": "Deze website maakt gebruik van cookies om de gebruikerservaring te verbeteren.",
+    "button": "Geweldig!"
+  },
+  "languageSelector": "Kies uw taal",
+  "javascript": "De F1 kalender website werkt het best met Javascript ingeschakeld.",
+  "footer": {
+    "coffee": "Steun F1 kalender, trakteer ons op een biertje.",
+    "twitter": "Vind ons op Twitter",
+    "github": "Open Source op GitHub",
+    "issue": "Een probleem gevonden? Rapporteer het",
+    "links": {
+      "wereOn": "Vind ons op",
+      "openSourcedOn": "Open Source op",
+      "spottedIssue": "Een probleem gevonden?",
+      "spottedReport": "Rapporteer"
+    }
+  }
+}

--- a/locales/nl/generate.json
+++ b/locales/nl/generate.json
@@ -1,0 +1,28 @@
+{
+  "form": {
+    "title": "Genereer Kalender",
+    "description": "Eerst, kies welke F1 race weekend sessies je wilt toevoegen aan je kalender:",
+    "fp1": "Vrije Training 1",
+    "fp2": "Vrije Training 2",
+    "fp3": "Vrije Training 3",
+    "qualifying": "Kwalificatie",
+    "grandPrix": "Grote Prijs Race",
+    "reminder": "Stel een herinnering in",
+    "reminderContinued": "enkele minuten voor elk evenement in je seizoenskalender.",
+    "button": "Haal de kalender op",
+    "buttonSubmitted": "Ingediend",
+    "nonOptionsSelected": "Gelieve minstens één sessie te selecteren voor je kalender."
+  },
+  "download": {
+    "title": "Selecteer het type kalender",
+    "webcalTitle": "Voor mobiel of computer",
+    "webcalDescription": "Automatisch de kalender aan het updaten voor applicaties zoals Outlook en macOS kalender.",
+    "webcalButton": "Ophalen",
+    "gcalTitle": "Voor Google Kalender",
+    "gcalDescription": "Om deze kalender toe te voegen, gelieve de link te kopiëren en te plakken in Google Kalender",
+    "gcalDescriptionLink": "gedetailleerde instructies",
+    "icsTitle": "Download ICS Bestand",
+    "icsDescription": "Kalender die niet wordt bijgewerkt (.ics) voor digitale kalenders die niet omkunnen met automatische updates.",
+    "icsButton": "Download"
+  }
+}

--- a/locales/nl/timezones.json
+++ b/locales/nl/timezones.json
@@ -1,0 +1,3 @@
+{
+  "title": "Kies een tijdzone..."
+}

--- a/locales/nl/years.json
+++ b/locales/nl/years.json
@@ -1,0 +1,3 @@
+{
+  "title": "Kies een jaar..."
+}


### PR DESCRIPTION
- I tried to keep the translations neutral between Dutch (nl-nl) and Flemish (nl-be). Both have equal spelling but they also have different word usage and sometimes word meaning.
- Struggled a bit with capitalization in some places but tried to always keep it equal with the English source. Trauma from making inconsistent capitalization in each and every project I've made in my life myself.
- Went a bit away from the instructions in common.json. The subtitle has the order of race, qualification and then free practice. In my translation I kept this order in the meta description while in the English version the meta description is changed to the order of race, free practice and then qualification. It's 157 characters so follows SEO guidelines.