### PR TITLE
emilia-romaga -> emilia-romagna

### DIFF
--- a/db/2020.json
+++ b/db/2020.json
@@ -211,8 +211,8 @@
       "longitude": 11.713808,
       "tbc": true,
       "round": 13,
-      "slug": "emilia-romaga-grand-prix",
-      "localeKey": "emilia-romaga-grand-prix",
+      "slug": "emilia-romagna-grand-prix",
+      "localeKey": "emilia-romagna-grand-prix",
       "sessions": {
         "fp1": "2020-10-31T09:00:00Z",
         "qualifying": "2020-10-31T13:00:00Z",

--- a/locales/cs/calendar.json
+++ b/locales/cs/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Tuscan Grand Prix",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/da/calendar.json
+++ b/locales/da/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Tuscan Grand Prix",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/de/calendar.json
+++ b/locales/de/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Tuscan Grand Prix",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/en/calendar.json
+++ b/locales/en/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Tuscan Grand Prix",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/es/calendar.json
+++ b/locales/es/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Tuscan Grand Prix",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/fi/calendar.json
+++ b/locales/fi/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Toscanan GP",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/fr/calendar.json
+++ b/locales/fr/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Tuscan Grand Prix",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/hr/calendar.json
+++ b/locales/hr/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Velika nagrada Toskane (Italija)",
     "eifel-grand-prix": "Velika nagrada Eifela (Njemačka)",
     "portuguese-grand-prix": "Velika nagrada Portugala",
-    "emilia-romaga-grand-prix": "Velika nagrada Emilije Romagne (Italija)"
+    "emilia-romagna-grand-prix": "Velika nagrada Emilije Romagne (Italija)"
   }
 }

--- a/locales/it/calendar.json
+++ b/locales/it/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Gran Premio della Toscana",
     "eifel-grand-prix": "Gran Premio dell'Eifel",
     "portuguese-grand-prix": "Gran Premio del Portogallo",
-    "emilia-romaga-grand-prix": "Gran Premio dell'Emilia Romagna"
+    "emilia-romagna-grand-prix": "Gran Premio dell'Emilia Romagna"
   }
 }

--- a/locales/nl/calendar.json
+++ b/locales/nl/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Grote Prijs van Toscane",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/pl/calendar.json
+++ b/locales/pl/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Grand Prix Toskanii",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/pt-BR/calendar.json
+++ b/locales/pt-BR/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "GP da Toscana Ferrari 1000",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/ru/calendar.json
+++ b/locales/ru/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Гран-при Тосканы",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/sv/calendar.json
+++ b/locales/sv/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Toscanas Grand Prix",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }

--- a/locales/zh/calendar.json
+++ b/locales/zh/calendar.json
@@ -48,6 +48,6 @@
     "tuscan-grand-prix": "Tuscan Grand Prix",
     "eifel-grand-prix": "Eifel Grand Prix",
     "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romaga-grand-prix": "Emilia Romagna Grand Prix"
+    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix"
   }
 }


### PR DESCRIPTION
The name of the region Emilia Romagna has a typo, this fixes it across all involved files.