### PR TITLE
French translations for the last added Grand Prix

### DIFF
--- a/locales/fr/calendar.json
+++ b/locales/fr/calendar.json
@@ -45,11 +45,11 @@
     "mexico-grand-prix": "Grand Prix du Mexique",
     "brazilian-grand-prix": "Grand Prix du Brésil",
     "abu-dhabi-grand-prix": "Grand Prix d'Abou Dabi",
-    "tuscan-grand-prix": "Tuscan Grand Prix",
-    "eifel-grand-prix": "Eifel Grand Prix",
-    "portuguese-grand-prix": "Portuguese Grand Prix",
-    "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix",
-    "sakhir-grand-prix": "Sakhir (Bahrain) Grand Prix",
-    "turkish-grand-prix": "Turkish Grand Prix"
+    "tuscan-grand-prix": "Grand Prix de Toscane",
+    "eifel-grand-prix": "Grand Prix de l'Eifel",
+    "portuguese-grand-prix": "Grand Prix du Portugal",
+    "emilia-romagna-grand-prix": "Grand Prix d'Émilie-Romagne",
+    "sakhir-grand-prix": "Grand Prix de Sakhir (Bahrein)",
+    "turkish-grand-prix": "Grand Prix de Turquie"
   }
 }


### PR DESCRIPTION
Hi!

Noticed the French were missing some translations for the last two batches of Covid calendar Grand Prix.

I added them in this, based on https://f1i.auto-moto.com/calendrier-f1-2020-dates-horaires-gp/ for name accuracy (auto moto is a pretty reputable publication in france, I trust them to have the names right)