### PR TITLE
Changed "Get" button translation

### DIFF
--- a/locales/uk/generate.json
+++ b/locales/uk/generate.json
@@ -17,7 +17,7 @@
     "title": "Виберіть тип календаря",
     "webcalTitle": "Для мобільного чи ПК",
     "webcalDescription": "Календар iз автомантичним оновленням події для таких програм як Outlook або Календар на Mac.",
-    "webcalButton": "Отримати",
+    "webcalButton": "Додати",
     "gcalTitle": "Для Календаря Google",
     "gcalDescription": "Щоб додати цей календар, скопіюйте та вставте це посилання до Календаря Google",
     "gcalDescriptionLink": "детальні інструкції",


### PR DESCRIPTION
The new meaning is "add" which reflects the action better, since it triggers the addition of the calendar subscription.