### PR TITLE
W Series typo and keywoard correction

### DIFF
--- a/locales/cs/wseries.json
+++ b/locales/cs/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/da/wseries.json
+++ b/locales/da/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/de/wseries.json
+++ b/locales/de/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/en/wseries.json
+++ b/locales/en/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/fi/wseries.json
+++ b/locales/fi/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/fr/wseries.json
+++ b/locales/fr/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/hr/wseries.json
+++ b/locales/hr/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/nl/wseries.json
+++ b/locales/nl/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/no/wseries.json
+++ b/locales/no/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/pl/wseries.json
+++ b/locales/pl/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/sl/wseries.json
+++ b/locales/sl/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/sq/wseries.json
+++ b/locales/sq/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/uk/wseries.json
+++ b/locales/uk/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }

--- a/locales/zh/wseries.json
+++ b/locales/zh/wseries.json
@@ -3,8 +3,8 @@
 	"subtitle": "Races, Qualifying & Practice Sessions",
 	"seo": {
 		"title": "W Series Calendar {{year}} - Race Times and Dates",
-		"description": "W Seroes Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-		"keywords": "wseries, w-series, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+		"description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+		"keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
 	},
 	"footnote": "W Series Calendar is not affiliated with W Series."
 }


### PR DESCRIPTION
Fixed a typo on W Series and changed "e prix" to "prix" since W Series are not part of the Formula E.