### PR TITLE
Update F2 and F3 schedules for Sochi

### DIFF
--- a/_db/f2/2021.json
+++ b/_db/f2/2021.json
@@ -89,8 +89,8 @@
 			"slug": "russian",
 			"localeKey": "russian",
 			"sessions": {
-				"practice": "2021-09-24T09:55:00Z",
-				"qualifying": "2021-09-24T14:20:00Z",
+				"practice": "2021-09-24T07:05:00Z",
+				"qualifying": "2021-09-24T13:25:00Z",
 				"sprint1": "2021-09-25T07:30:00Z",
 				"sprint2": "2021-09-25T13:45:00Z",
 				"feature": "2021-09-26T08:20:00Z"

--- a/_db/f2/2021.json
+++ b/_db/f2/2021.json
@@ -85,14 +85,13 @@
 			"location": "Sochi",
 			"latitude": 43.6203,
 			"longitude": 39.712,
-			"tbc": true,
 			"round": 6,
 			"slug": "russian",
 			"localeKey": "russian",
 			"sessions": {
-				"practice": "2021-09-24T06:45:00Z",
-				"qualifying": "2021-09-24T10:30:00Z",
-				"sprint1": "2021-09-25T07:20:00Z",
+				"practice": "2021-09-24T09:55:00Z",
+				"qualifying": "2021-09-24T14:20:00Z",
+				"sprint1": "2021-09-25T07:30:00Z",
 				"sprint2": "2021-09-25T13:45:00Z",
 				"feature": "2021-09-26T08:20:00Z"
 			}

--- a/_db/f3/2021.json
+++ b/_db/f3/2021.json
@@ -107,17 +107,16 @@
 			"location": "Sochi",
 			"latitude": 43.6203,
 			"longitude": 39.712,
-			"tbc": true,
 			"round": 7,
 			"slug": "russian",
 			"localeKey": "russian",
 			"affiliate": "https://motorsporttickets.com/en-gb/f1/russia/tickets?af=165390",
 			"sessions": {
-				"practice": "2021-09-24T06:45:00Z",
-				"qualifying": "2021-09-24T10:30:00Z",
-				"race1": "2021-09-25T07:20:00Z",
-				"race2": "2021-09-25T13:45:00Z",
-				"race3": "2021-09-26T08:20:00Z"
+				"practice": "2021-09-24T07:05:00Z",
+				"qualifying": "2021-09-24T13:25:00Z",
+				"race1": "2021-09-25T05:35:00Z",
+				"race2": "2021-09-25T10:40:00Z",
+				"race3": "2021-09-26T06:55:00Z"
 			}
 		}
 	]

--- a/_db/f3/2021.json
+++ b/_db/f3/2021.json
@@ -112,8 +112,8 @@
 			"localeKey": "russian",
 			"affiliate": "https://motorsporttickets.com/en-gb/f1/russia/tickets?af=165390",
 			"sessions": {
-				"practice": "2021-09-24T07:05:00Z",
-				"qualifying": "2021-09-24T13:25:00Z",
+				"practice": "2021-09-24T05:55:00Z",
+				"qualifying": "2021-09-24T10:00:00Z",
 				"race1": "2021-09-25T05:35:00Z",
 				"race2": "2021-09-25T10:40:00Z",
 				"race3": "2021-09-26T06:55:00Z"


### PR DESCRIPTION
FYI I'm generating these with a script that looks through the timetables on the F1 website, which I uploaded to https://github.com/lerhond/f1/blob/script/scripts/get_schedule.py - the code is a bit messy and it gets slightly confused with the postponed races later in the year, so changes need to be checked manually, but mostly works fine. Just leaving it here in case you might want to use it for future updates.