### PR TITLE
#639 Sprint qualifying translation for Hungarian

### DIFF
--- a/locales/hu/localization.json
+++ b/locales/hu/localization.json
@@ -22,6 +22,7 @@
         "qualifying": "Időmérő",
         "qualifying1": "1. Időmérő",
         "qualifying2": "2. Időmérő",
+        "sprintQualifying": "Időmérő edzés",
         "semifinal": "Semi Final",
         "warmup": "Warmup",
         "race": "Futam",


### PR DESCRIPTION
`sprintQualifying` entry was missing in translation file for Hungarian, adding it