### PR TITLE
Improve Dutch translations

### DIFF
--- a/locales/nl/localization.json
+++ b/locales/nl/localization.json
@@ -1,95 +1,95 @@
 {
     "date": "Datum",
     "time": "Tijd",
-    "showPreviousRaces": "Show Previous Races",
-    "hidePreviousRaces": "Hide Previous Races",
+    "showPreviousRaces": "Toon vorige races",
+    "hidePreviousRaces": "Verberg vorige races",
     "badges": {
         "tbc": "TB",
         "tbc_title": "Te beslissen",
-        "tickets": "Ticketten",
+        "tickets": "Tickets",
         "canceled": "Geannuleerd",
-        "next": "VOLGENDE"
+        "next": "Volgende"
     },
     "schedule": {
         "fp1": "Vrije Training 1",
         "fp2": "Vrije Training 2",
         "fp3": "Vrije Training 3",
         "shakedown": "Shakedown",
-        "practice1": "Practice 1",
-        "practice2": "Practice 2",
-        "practice3": "Practice 3",
-        "practice": "Practice",
+        "practice1": "Training 1",
+        "practice2": "Training 2",
+        "practice3": "Training 3",
+        "practice": "Training",
         "qualifying": "Kwalificatie",
         "qualifying1": "Kwalificatie 1",
         "qualifying2": "Kwalificatie 2",
-        "sprintQualifying": "Sprint Qualifying",
-        "semifinal": "Semi Final",
-        "warmup": "Warmup",
+        "sprintQualifying": "Sprintkwalificatie",
+        "semifinal": "Halve finale",
+        "warmup": "Formatieronde",
         "race": "Race",
         "race1": "Race 1",
         "race2": "Race 2",
         "race3": "Race 3",
-        "gp": "Grote Prijs Race",
+        "gp": "Grand Prix",
         "sprint1": "Sprint 1",
         "sprint2": "Sprint 2",
         "feature": "Feature"
     },
     "races": {
-        "austrian-grand-prix": "Grote Prijs van Oostenrijk",
-        "steiermark-grand-prix": "Grote Prijs van Stiermarken (Oostenrijk)",
-        "hungarian-grand-prix": "Grote Prijs van Hongarije",
-        "british-grand-prix": "Grote Prijs van Groot-Brittannië",
-        "anniversary-british-grand-prix": "Grote Prijs 70 jaar jubileum (Groot-Brittannië)",
-        "spanish-grand-prix": "Grote Prijs van Spanje",
-        "belgian-grand-prix": "Grote Prijs van België",
-        "italian-grand-prix": "Grote Prijs van Italië",
-        "australian-grand-prix": "Grote Prijs van Australië",
-        "bahrain-grand-prix": "Grote Prijs van Bahrein",
-        "vietnamese-grand-prix": "Grote Prijs van Vietnam",
-        "china-grand-prix": "Grote Prijs van China",
-        "dutch-grand-prix": "Grote Prijs van Nederland",
-        "monaco-grand-prix": "Grote Prijs van Monaco",
-        "azerbaijan-grand-prix": "Grote Prijs van Azerbeidzjan",
-        "canadian-grand-prix": "Grote Prijs van Canada",
-        "french-grand-prix": "Grote Prijs van Frankrijk",
-        "singapore-grand-prix": "Grote Prijs van Singapore",
-        "russian-grand-prix": "Grote Prijs van Rusland",
-        "japanese-grand-prix": "Grote Prijs van Japan",
-        "us-grand-prix": "Grote Prijs van de Verenigde Staten van Amerika",
-        "mexico-grand-prix": "Grote Prijs van Mexico-Stad",
-        "brazilian-grand-prix": "Grote Prijs van Brazilië",
-        "abu-dhabi-grand-prix": "Grote Prijs van Abu Dhabi",
-        "tuscan-grand-prix": "Grote Prijs van Toscane",
-        "eifel-grand-prix": "Eifel Grand Prix",
-        "portuguese-grand-prix": "Portuguese Grand Prix",
-        "emilia-romagna-grand-prix": "Emilia Romagna Grand Prix",
-        "sakhir-grand-prix": "Sakhir (Bahrain) Grand Prix",
-        "turkish-grand-prix": "Turkish Grand Prix",
-        "saudi-arabia-grand-prix": "Saudi Arabian Grand Prix",
-        "qatar-grand-prix" : "Qatar Grand Prix",
-		"miami-grand-prix" : "Miami Grand Prix"
+        "austrian-grand-prix": "Grand Prix van Oostenrijk",
+        "steiermark-grand-prix": "Grand Prix van Stiermarken (Oostenrijk)",
+        "hungarian-grand-prix": "Grand Prix van Hongarije",
+        "british-grand-prix": "Grand Prix van Groot-Brittannië",
+        "anniversary-british-grand-prix": "Grand Prix 70 jaar jubileum (Groot-Brittannië)",
+        "spanish-grand-prix": "Grand Prix van Spanje",
+        "belgian-grand-prix": "Grand Prix van België",
+        "italian-grand-prix": "Grand Prix van Italië",
+        "australian-grand-prix": "Grand Prix van Australië",
+        "bahrain-grand-prix": "Grand Prix van Bahrein",
+        "vietnamese-grand-prix": "Grand Prix van Vietnam",
+        "china-grand-prix": "Grand Prix van China",
+        "dutch-grand-prix": "Grand Prix van Nederland",
+        "monaco-grand-prix": "Grand Prix van Monaco",
+        "azerbaijan-grand-prix": "Grand Prix van Azerbeidzjan",
+        "canadian-grand-prix": "Grand Prix van Canada",
+        "french-grand-prix": "Grand Prix van Frankrijk",
+        "singapore-grand-prix": "Grand Prix van Singapore",
+        "russian-grand-prix": "Grand Prix van Rusland",
+        "japanese-grand-prix": "Grand Prix van Japan",
+        "us-grand-prix": "Grand Prix van de Verenigde Staten van Amerika",
+        "mexico-grand-prix": "Grand Prix van Mexico-Stad",
+        "brazilian-grand-prix": "Grand Prix van Brazilië",
+        "abu-dhabi-grand-prix": "Grand Prix van Abu Dhabi",
+        "tuscan-grand-prix": "Grand Prix van Toscane",
+        "eifel-grand-prix": "Grand Prix van de Eifel",
+        "portuguese-grand-prix": "Grand Prix van Portugal",
+        "emilia-romagna-grand-prix": "Grand Prix van Emilia-Romagna",
+        "sakhir-grand-prix": "Grand Prix van Sakhir (Bahrain)",
+        "turkish-grand-prix": "Grand Prix van Turkije",
+        "saudi-arabia-grand-prix": "Grand Prix van Saoedi-Arabië",
+        "qatar-grand-prix" : "Grand Prix van Qatar",
+		"miami-grand-prix" : "Grand Prix van Miami"
 	},
 	"options": {
-        "calendar": "Voeg deze race datums en starttijden toe aan je kalender",
+        "calendar": "Voeg deze race datums en starttijden toe aan je agenda",
         "email": "Ontvang herinneringen via email",
         "timezonePicker": {
             "showing": "Starttijden voor",
             "pick": "Kies een tijdzone..."
         },
         "formatPicker": {
-            "title": "Time Format",
-            "12hr": "12-Hour Time",
-            "24hr": "24-Hour Time"
+            "title": "Tijdformaat",
+            "12hr": "12-uurformaat",
+            "24hr": "24-uurformaat"
         },
         "button": "Gedaan"
     },
     "contribute": "Help ons",
     "languageSelector": "Kies uw taal",
-    "javascript": "De F1 kalender website werkt het best met Javascript ingeschakeld.",
+    "javascript": "De F1 agenda website werkt het best met Javascript ingeschakeld.",
     "footer": {
-        "coffee": "Steun F1 kalender, trakteer ons op een biertje.",
+        "coffee": "Steun F1 agenda, trakteer ons op een biertje.",
         "twitter": "Vind ons op Twitter",
-        "github": "Open Source op GitHub",
+        "github": "Open broncode op GitHub",
         "issue": "Een probleem gevonden? Rapporteer het",
         "links": {
             "wereOn": "Vind ons op",
@@ -99,31 +99,31 @@
         }
     },
     "form": {
-        "title": "Genereer Kalender",
-        "description": "Eerst, kies welke F1 race weekend sessies je wilt toevoegen aan je kalender:",
+        "title": "Genereer agenda",
+        "description": "Eerst, kies welke F1 raceweekend sessies je wilt toevoegen aan je agenda:",
         "reminder": "Stel een herinnering in",
-        "reminderContinued": "enkele minuten voor elk evenement in je seizoenskalender.",
-        "button": "Haal de kalender op",
+        "reminderContinued": "enkele minuten voor elk evenement in je seizoensagenda.",
+        "button": "Haal de agenda op",
         "buttonSubmitted": "Ingediend",
-        "nonOptionsSelected": "Gelieve minstens één sessie te selecteren voor je kalender.",
-        "attention": "The three 2021 Sprint Qualifying sessions will be included when Qualifying is selected. If these sessions remain for 2022 we'll introduce a new option."
+        "nonOptionsSelected": "Gelieve minstens één sessie te selecteren voor je agenda.",
+        "attention": "De drie sprintkwalificatie sessies van 2021 zijn inbegrepen wanneer de kwalificatie optie geselecteerd is. Als deze sessies blijven in 2022 zullen we een nieuwe optie introduceren."
     },
     "download": {
-        "title": "Selecteer het type kalender",
+        "title": "Selecteer het type agenda",
         "webcalTitle": "Voor mobiel of computer",
-        "webcalDescription": "Automatisch de kalender aan het updaten voor applicaties zoals Outlook en macOS kalender.",
+        "webcalDescription": "Updatet de agenda automatisch. Voor applicaties zoals Outlook en macOS agenda.",
         "webcalButton": "Ophalen",
-        "gcalTitle": "Voor Google Kalender",
-        "gcalDescription": "Om deze kalender toe te voegen, gelieve de link te kopiëren en te plakken in Google Kalender",
+        "gcalTitle": "Voor Google Agenda",
+        "gcalDescription": "Om deze agenda toe te voegen, gelieve de link te kopiëren en te plakken in Google Agenda",
         "gcalDescriptionLink": "gedetailleerde instructies",
         "icsTitle": "Download ICS Bestand",
-        "icsDescription": "Kalender die niet wordt bijgewerkt (.ics) voor digitale kalenders die niet omkunnen met automatische updates.",
+        "icsDescription": "Agenda die niet automatisch wordt bijgewerkt (.ics). Voor digitale agenda's die niet overweg kunnen met automatische updates.",
         "icsButton": "Download"
     },
     "subscribe": {
         "title": "Inschrijven",
-        "description": "Ontvang een herinnering via email voor de start van elk race weekend.",
-        "label": "Email Adres",
+        "description": "Ontvang een herinnering via email voor de start van elk raceweekend.",
+        "label": "E-mailadres",
         "button": "Schrijf me in"
     },
     "timezones": {
@@ -133,82 +133,82 @@
         "title": "Kies een jaar..."
     },
     "f1": {
-        "title": "F1 Kalender",
-        "subtitle": "Race, Kwalificatie & Vrije Training Sessies",
+        "title": "F1 Agenda",
+        "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "F1 Kalender {{year}} - Formula One Race Times and Dates",
-            "description": "Formule 1 Kalender voor seizoen {{year}} met alle F1 race-, kwalificatie- en vrije training sessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
-            "keywords": "F1, formule 1, formule één, race tijden, races, herinnering, alarm, waarschuwing, grote prijzen, grote prijs, kalender, datums, starttijden, kwalificatie, oefening, vrije training, Londen, Europa, {{year}}"
+            "title": "F1 Agenda {{year}} - Formule 1 Race tijden en datums",
+            "description": "Formule 1 Agenda voor seizoen {{year}} met alle F1 race-, kwalificatie- en vrije training sessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "F1, formule 1, formule één, race tijden, races, herinnering, alarm, waarschuwing, grote prijzen, Grand Prix, agenda, datums, starttijden, kwalificatie, oefening, vrije training, Londen, Europa, {{year}}"
         },
-        "footnote": "Formula One, Formula 1, F1 & Grand Prix are trademarks of Formula One Licensing BV."
+        "footnote": "Formula One, Formula 1, F1 & Grand Prix zijn handelsmerken van Formula One Licensing BV."
     },
     "f2": {
-        "title": "F2 Calendar",
-        "subtitle": "Races, Qualifying & Practice Sessions",
+        "title": "F2 Agenda",
+        "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "F2 Calendar {{year}} - Formula Two Race Times and Dates",
-            "description": "Formula Two Calendar for {{year}} season with all F2 grand prix races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+            "title": "F2 Agenda {{year}} - Formule 2 Race tijden en datums",
+            "description": "Formula Two Agenda for {{year}} met alle F2 Grand Prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
             "keywords": "placeholder"
         },
-        "footnote": "FIA FORMULA 2 CHAMPIONSHIP, FIA FORMULA 2, FORMULA 2, F2 are trademarks of the FIA."
+        "footnote": "FIA FORMULA 2 CHAMPIONSHIP, FIA FORMULA 2, FORMULA 2, F2 zijn handelsmerken van de FIA."
     },
     "f3": {
-        "title": "F3 Calendar",
-        "subtitle": "Races, Qualifying & Practice Sessions",
+        "title": "F3 Agenda",
+        "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "F3 Calendar {{year}} - Formula Three Race Times and Dates",
-            "description": "Formula Three Calendar for {{year}} season with all F3 grand prix races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-            "keywords": "F3, formula three, race times, races, reminder, alerts, grands prix, grand prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+            "title": "F3 Agenda {{year}} - Formule 3 Race tijden en datums",
+            "description": "Formula 3 Agenda voor seizoen {{year}} met alle F3 Grand Prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "F3, formula three, race tijden, races, herinnering, alerts, grands prix, grand prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
         },
-        "footnote": "FIA FORMULA 3 CHAMPIONSHIP, FIA FORMULA 3, FORMULA 3, F3 are trademarks of the FIA."
+        "footnote": "FIA FORMULA 3 CHAMPIONSHIP, FIA FORMULA 3, FORMULA 3, F3 zijn handelsmerken van de FIA."
     },
     "fe": {
-        "title": "Formula E Calendar",
-        "subtitle": "Races, Qualifying & Practice Sessions",
+        "title": "Formula E Agenda",
+        "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "Formula E Calendar {{year}} - Formula E Race Times and Dates",
-            "description": "Formula E Calendar for {{year}} season with all Formula E e-prix races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-            "keywords": "FE, formula e, race times, races, reminder, alerts, e prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+            "title": "Formula E Agenda {{year}} - Formule E Race tijden en datums",
+            "description": "Formula E Agenda voor seizoen {{year}} met alle Formule E e-prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "FE, formula e, race tijden, races, herinnering, alerts, e prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
         },
-        "footnote": "Formula-E, FIA FORMULA-E CHAMPIONSHIP & E-Prix are trademarks of the FIA."
+        "footnote": "Formula-E, FIA FORMULA-E CHAMPIONSHIP & E-Prix zijn handelsmerken van de FIA."
     },
     "indycar": {
-        "title": "IndyCar Calendar",
-        "subtitle": "Races, Qualifying & Practice Sessions",
+        "title": "IndyCar Agenda",
+        "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "IndyCar Calendar {{year}} - Race Times and Dates",
-            "description": "IndyCar Calendar for {{year}} season with all IndyCar races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-            "keywords": "IndyCar, race times, races, reminder, alerts, calendar, dates, start times, qualifying, practice, {{year}}"
+            "title": "IndyCar Agenda {{year}} - Race tijden en datums",
+            "description": "IndyCar Agenda voor seizoen {{year}} met alle IndyCar races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "IndyCar, race tijden, races, herinnering, alerts, agenda, datums, starttijden, kwalificatie, training, {{year}}"
         },
-        "footnote": "IndyCar is a registered trademark of Brickyard Trademarks, Inc"
+        "footnote": "IndyCar is een geregistreerd handelsmerk van Brickyard Trademarks, Inc"
     },
     "motogp": {
-        "title": "MotoGP Calendar",
-        "subtitle": "Races, Qualifying & Practice Sessions",
+        "title": "MotoGP Agenda",
+        "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "MotoGP Calendar {{year}} - Race Times and Dates",
-            "description": "MotoGP Calendar for {{year}} season with all MotoGP races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-            "keywords": "MotoGP, race times, races, reminder, alerts, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+            "title": "MotoGP Agenda {{year}} - Race tijden en datums",
+            "description": "MotoGP Agenda voor seizoen {{year}} met alle MotoGP races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "MotoGP, race tijden, races, herinnering, alerts, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
         },
         "footnote": ""
     },
     "wseries": {
-        "title": "W Series Calendar",
-        "subtitle": "Races, Qualifying & Practice Sessions",
+        "title": "W Series Agenda",
+        "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "W Series Calendar {{year}} - Race Times and Dates",
-            "description": "W Series Calendar for {{year}} season with all W Series races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-            "keywords": "wseries, w-series, race times, races, reminder, alerts, prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+            "title": "W Series Agenda {{year}} - Race tijden en datums",
+            "description": "W Series Agenda voor seizoen {{year}} met alle W-series races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "wseries, w-series, race tijden, races, herinnering, alerts, prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
         },
-        "footnote": "W Series Calendar is not affiliated with W Series."
+        "footnote": "W Series Agenda is niet verbonden aan W Series."
     },
     "extremee": {
-        "title": "Extreme E Calendar",
-        "subtitle": "Races, Qualifying & Practice Sessions",
+        "title": "Extreme E Agenda",
+        "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "Extreme E Calendar {{year}} - Extreme E Race Times and Dates",
-            "description": "Extreme E Calendar for {{year}} season with all Extreme E xprix races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-            "keywords": "Extreme E, race times, races, reminder, alerts, x prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+            "title": "Extreme E Agenda {{year}} - Extreme E Race tijden en datums",
+            "description": "Extreme E Agenda voor seizoen {{year}} met alle Extreme E xprix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "Extreme E, race tijden, races, herinnering, alerts, x prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
         },
         "footnote": ""
     }


### PR DESCRIPTION
- Add missing translations
- Improve existing translations:
    - Use 'Grand Prix' instead of 'Grote Prijs'. No one says that. 
    - Spell word compositions correctly (e.g. 'E-mailadres' instead of 'Email Adres')