### PR TITLE
Add note about reminders not working with Google Calendar

### DIFF
--- a/locales/en/localization.json
+++ b/locales/en/localization.json
@@ -117,6 +117,7 @@
 		"gcalTitle": "For Google Calendar",
 		"gcalDescription": "To add this calendar, copy and paste this URL into Google Calendar",
 		"gcalDescriptionLink": "detailed instructions",
+		"gcalNotificationNotice": "Google Calendar doesn't honor the reminders on remote calendars. Event notifications can be configured within the calendar's settings after it's been added.",
 		"icsTitle": "Download ICS File",
 		"icsDescription": "Non-updating calendar (.ics) for calendars that can’t handle updating subscriptions.",
 		"icsButton": "Download"

--- a/pages/generate.js
+++ b/pages/generate.js
@@ -158,6 +158,28 @@ function Generate(props) {
 							<h4 className="uppercase mb-4">
 								{t("localization:download.gcalTitle")}
 							</h4>
+							{form.alarm && <div className="bg-black rounded-md">
+								<p className="mb-4 p-3 w-fill flex">
+									<svg
+										className="flex-none w-6 h-full"
+										aria-hidden="true"
+										focusable="false"
+										data-prefix="far"
+										data-icon="bell"
+										role="img"
+										xmlns="http://www.w3.org/2000/svg"
+										viewBox="0 0 512 512"
+									>
+										<path
+											fill="currentColor"
+											d="M256 32V49.88C328.5 61.39 384 124.2 384 200V233.4C384 278.8 399.5 322.9 427.8 358.4L442.7 377C448.5 384.2 449.6 394.1 445.6 402.4C441.6 410.7 433.2 416 424 416H24C14.77 416 6.365 410.7 2.369 402.4C-1.628 394.1-.504 384.2 5.26 377L20.17 358.4C48.54 322.9 64 278.8 64 233.4V200C64 124.2 119.5 61.39 192 49.88V32C192 14.33 206.3 0 224 0C241.7 0 256 14.33 256 32V32zM216 96C158.6 96 112 142.6 112 200V233.4C112 281.3 98.12 328 72.31 368H375.7C349.9 328 336 281.3 336 233.4V200C336 142.6 289.4 96 232 96H216zM288 448C288 464.1 281.3 481.3 269.3 493.3C257.3 505.3 240.1 512 224 512C207 512 190.7 505.3 178.7 493.3C166.7 481.3 160 464.1 160 448H288z"
+										/>
+									</svg>
+									<span className="ml-2">
+										{t("localization:download.gcalNotificationNotice")}
+									</span>
+								</p>
+							</div>}
 							<p className="mb-4">
 								{t("localization:download.gcalDescription")} (
 								<a


### PR DESCRIPTION
I noticed that Google Calendar weirdly seems to ignore VALARM elements on synced external calendars. This results in calendars not having the configured reminder from the UI as might be expected.

There's nothing obvious that can be done about that, but I thought it might be worth popping a note on the UI if there's a reminder configured in the Google Calendar section.

The icon is a free one from Font Awesome, assuming the cog is also from there!

![image](https://user-images.githubusercontent.com/7294642/157850736-6aa38381-80cf-4257-aa01-890e62f8b27d.png)
