### PR TITLE
Update sessionLengths in F2 and F3 configs

### DIFF
--- a/_db/f2/config.json
+++ b/_db/f2/config.json
@@ -20,8 +20,7 @@
 	"sessionLengths": {
 		"practice": 45,
 		"qualifying": 30,
-		"sprint1": 45,
-		"sprint2": 45,
+		"sprint": 45,
 		"feature": 60
 	},
 	"supportsEmailReminders": false,

--- a/_db/f3/config.json
+++ b/_db/f3/config.json
@@ -21,7 +21,7 @@
 		"practice": 45,
 		"qualifying": 30,
 		"sprint": 40,
-		"race": 40
+		"feature": 45
 	},
 	"supportsEmailReminders": false,
 	"notice": "The F3 weekend format has changed. You may need to regenerate your calendar to account for the different sessions. Most sessions are still TBC. Calendar will be updated once details are confirmed."


### PR DESCRIPTION
Update the sessionLengths keys in the F2 and F3 config files. Also, the F3 feature race is now 45 minutes according to https://www.fiaformula3.com/About/6Iosy860VzDs0INyfKw37E/the-rules-and-regulations-f3