### PR TITLE
Disable f1 email reminders temporarily

### DIFF
--- a/_db/f1/config.json
+++ b/_db/f1/config.json
@@ -22,5 +22,5 @@
 		"sprint":60,
 		"gp":120
 	},
-	"supportsEmailReminders": true
+	"supportsEmailReminders": false
 }


### PR DESCRIPTION
To be used to temporarily hide email subscription option while transitioning to a different tool for maintaining email subscriptions.