### PR TITLE
Change Dutch locale for Sprint.

### DIFF
--- a/locales/nl/localization.json
+++ b/locales/nl/localization.json
@@ -24,7 +24,7 @@
         "qualifying1": "Kwalificatie 1",
         "qualifying2": "Kwalificatie 2",
         "sprintQualifying": "Sprint Shootout",
-        "sprint": "Sprintkwalificatie",
+        "sprint": "Sprint",
         "semifinal": "Halve finale",
         "warmup": "Formatieronde",
         "race": "Race",


### PR DESCRIPTION
Current Dutch locale is "Sprintkwalificatie" which means "Sprint Qualifying" in English, but that is the incorrect term for how Sprint weekends work in the 2023 season. This PR changes it to "Sprint".