### PR TITLE
Fixing the 'Get Calendar' Button for other languages

### DIFF
--- a/src/app/[locale]/generate/form.tsx
+++ b/src/app/[locale]/generate/form.tsx
@@ -93,11 +93,11 @@ export default function Form() {
 			setState({
 				...form,
 				submitted: true,
-				webcalURL: `webcal://${calendarBaseURL}/${lang}/${process.env.NEXT_PUBLIC_SITE_KEY}-calendar${calendarSuffix}.ics`,
-				googleURL: `https://${calendarBaseURL}/${lang}/${
+				webcalURL: `webcal://${calendarBaseURL}/${locale}/${process.env.NEXT_PUBLIC_SITE_KEY}-calendar${calendarSuffix}.ics`,
+				googleURL: `https://${calendarBaseURL}/${locale}/${
 					process.env.NEXT_PUBLIC_SITE_KEY
 				}-calendar${calendarSuffix}.ics?t=${Date.now()}`,
-				downloadURL: `https://${calendarBaseURL}/${lang}/${process.env.NEXT_PUBLIC_SITE_KEY}-calendar${calendarSuffix}.ics`
+				downloadURL: `https://${calendarBaseURL}/${locale}/${process.env.NEXT_PUBLIC_SITE_KEY}-calendar${calendarSuffix}.ics`
 			});
 		} else {
 			setState({


### PR DESCRIPTION
closes #1580
I replaced 'lang' with 'locale' to resolve an error triggered upon button click. The issue was specific to non-English languages, as English was correctly handled by the existing code.