### PR TITLE
Fix malformed messages in dutch localization.json

### DIFF
--- a/locales/nl/localization.json
+++ b/locales/nl/localization.json
@@ -76,6 +76,7 @@
 	"options": {
         "calendar": "Voeg deze race datums en starttijden toe aan je agenda",
         "email": "Ontvang herinneringen via email",
+        "notifications": "Ontvang Push Notificaties",
         "timezonePicker": {
             "detect": "Detect",
             "showing": "Starttijden voor",
@@ -157,9 +158,9 @@
         "title": "F1 Agenda",
         "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "F1 Agenda {{year}} - Formule 1 Race tijden en datums",
-            "description": "Formule 1 Agenda voor seizoen {{year}} met alle F1 race-, kwalificatie- en vrije training sessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
-            "keywords": "F1, formule 1, formule één, race tijden, races, herinnering, alarm, waarschuwing, grote prijzen, Grand Prix, agenda, datums, starttijden, kwalificatie, oefening, vrije training, Londen, Europa, {{year}}"
+            "title": "F1 Agenda {year} - Formule 1 Race tijden en datums",
+            "description": "Formule 1 Agenda voor seizoen {year} met alle F1 race-, kwalificatie- en vrije training sessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "F1, formule 1, formule één, race tijden, races, herinnering, alarm, waarschuwing, grote prijzen, Grand Prix, agenda, datums, starttijden, kwalificatie, oefening, vrije training, Londen, Europa, {year}"
         },
         "footnote": "Formula One, Formula 1, F1 & Grand Prix zijn handelsmerken van Formula One Licensing BV."
     },
@@ -167,8 +168,8 @@
         "title": "F2 Agenda",
         "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "F2 Agenda {{year}} - Formule 2 Race tijden en datums",
-            "description": "Formula Two Agenda for {{year}} met alle F2 Grand Prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "title": "F2 Agenda {year} - Formule 2 Race tijden en datums",
+            "description": "Formula Two Agenda for {year} met alle F2 Grand Prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
             "keywords": "placeholder"
         },
         "footnote": "FIA FORMULA 2 CHAMPIONSHIP, FIA FORMULA 2, FORMULA 2, F2 zijn handelsmerken van de FIA."
@@ -177,9 +178,9 @@
         "title": "F3 Agenda",
         "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "F3 Agenda {{year}} - Formule 3 Race tijden en datums",
-            "description": "Formula 3 Agenda voor seizoen {{year}} met alle F3 Grand Prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
-            "keywords": "F3, formula three, race tijden, races, herinnering, alerts, grands prix, grand prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
+            "title": "F3 Agenda {year} - Formule 3 Race tijden en datums",
+            "description": "Formula 3 Agenda voor seizoen {year} met alle F3 Grand Prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "F3, formula three, race tijden, races, herinnering, alerts, grands prix, grand prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {year}"
         },
         "footnote": "FIA FORMULA 3 CHAMPIONSHIP, FIA FORMULA 3, FORMULA 3, F3 zijn handelsmerken van de FIA."
     },
@@ -187,9 +188,9 @@
         "title": "Formula E Agenda",
         "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "Formula E Agenda {{year}} - Formule E Race tijden en datums",
-            "description": "Formula E Agenda voor seizoen {{year}} met alle Formule E e-prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
-            "keywords": "FE, formula e, race tijden, races, herinnering, alerts, e prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
+            "title": "Formula E Agenda {year} - Formule E Race tijden en datums",
+            "description": "Formula E Agenda voor seizoen {year} met alle Formule E e-prix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "FE, formula e, race tijden, races, herinnering, alerts, e prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {year}"
         },
         "footnote": "Formula-E, FIA FORMULA-E CHAMPIONSHIP & E-Prix zijn handelsmerken van de FIA."
     },
@@ -197,9 +198,9 @@
         "title": "IndyCar Agenda",
         "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "IndyCar Agenda {{year}} - Race tijden en datums",
-            "description": "IndyCar Agenda voor seizoen {{year}} met alle IndyCar races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
-            "keywords": "IndyCar, race tijden, races, herinnering, alerts, agenda, datums, starttijden, kwalificatie, training, {{year}}"
+            "title": "IndyCar Agenda {year} - Race tijden en datums",
+            "description": "IndyCar Agenda voor seizoen {year} met alle IndyCar races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "IndyCar, race tijden, races, herinnering, alerts, agenda, datums, starttijden, kwalificatie, training, {year}"
         },
         "footnote": "IndyCar is een geregistreerd handelsmerk van Brickyard Trademarks, Inc"
     },
@@ -207,9 +208,9 @@
         "title": "MotoGP Agenda",
         "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "MotoGP Agenda {{year}} - Race tijden en datums",
-            "description": "MotoGP Agenda voor seizoen {{year}} met alle MotoGP races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
-            "keywords": "MotoGP, race tijden, races, herinnering, alerts, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
+            "title": "MotoGP Agenda {year} - Race tijden en datums",
+            "description": "MotoGP Agenda voor seizoen {year} met alle MotoGP races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "MotoGP, race tijden, races, herinnering, alerts, agenda, datums, starttijden, kwalificatie, training, London, Europe, {year}"
         },
         "footnote": ""
     },
@@ -217,9 +218,9 @@
         "title": "W Series Agenda",
         "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "W Series Agenda {{year}} - Race tijden en datums",
-            "description": "W Series Agenda voor seizoen {{year}} met alle W-series races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
-            "keywords": "wseries, w-series, race tijden, races, herinnering, alerts, prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
+            "title": "W Series Agenda {year} - Race tijden en datums",
+            "description": "W Series Agenda voor seizoen {year} met alle W-series races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "wseries, w-series, race tijden, races, herinnering, alerts, prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {year}"
         },
         "footnote": "W Series Agenda is niet verbonden aan W Series."
     },
@@ -227,9 +228,9 @@
         "title": "Extreme E Agenda",
         "subtitle": "Races, Kwalificaties & Trainingsessies",
         "seo": {
-            "title": "Extreme E Agenda {{year}} - Extreme E Race tijden en datums",
-            "description": "Extreme E Agenda voor seizoen {{year}} met alle Extreme E xprix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
-            "keywords": "Extreme E, race tijden, races, herinnering, alerts, x prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {{year}}"
+            "title": "Extreme E Agenda {year} - Extreme E Race tijden en datums",
+            "description": "Extreme E Agenda voor seizoen {year} met alle Extreme E xprix races, trainingen &amp; kwalificatiesessies. Stel herinneringen in. Alle tijdzones. Download of abonneer.",
+            "keywords": "Extreme E, race tijden, races, herinnering, alerts, x prix, agenda, datums, starttijden, kwalificatie, training, London, Europe, {year}"
         },
         "footnote": ""
     },
@@ -237,9 +238,9 @@
         "title": "F1 Academy Calendar",
         "subtitle": "Races, Qualifying & Practice Sessions",
         "seo": {
-            "title": "F1 Academy Calendar {{year}} - Formula One Race Times and Dates",
-            "description": "Formula One Academy Calendar for {{year}} season with all F1 Academy races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
-            "keywords": "F1, formula one, race times, races, reminder, alerts, grands prix, grand prix, calendar, dates, start times, qualifying, practice, London, Europe, {{year}}"
+            "title": "F1 Academy Calendar {year} - Formula One Race Times and Dates",
+            "description": "Formula One Academy Calendar for {year} season with all F1 Academy races, practice &amp; qualifying sessions. Set reminders feature. All world timezones. Download or subscribe.",
+            "keywords": "F1, formula one, race times, races, reminder, alerts, grands prix, grand prix, calendar, dates, start times, qualifying, practice, London, Europe, {year}"
         },
         "footnote": "F1 Acadamy, Formula One, Formula 1, F1 & Grand Prix are trademarks of Formula One Licensing BV."
     }


### PR DESCRIPTION
While checking the F1 calendar I saw the Title of the page became `Dear developer, please fix this message:`

- The issue was caused by malformed messages in the dutch localization.json
- Also noticed errors in the web console missing the translations for `notifications`. So added that one aswell.