### PR TITLE
Add a bottom border to the rows of the race table to improve readability

### DIFF
--- a/src/components/Race/RaceTR.tsx
+++ b/src/components/Race/RaceTR.tsx
@@ -19,6 +19,10 @@ export interface RaceRowTR {
 	slug: string;
 }
 
+const STYLES = {
+	border: 'border-solit border-b border-gray-700 last-of-type:border-none'
+}
+
 const RaceTR: FunctionComponent<RaceRowTR> = ({ hasMultipleFeaturedEvents, title, collapsed, hasOccured, isFeaturedSession, date, isNextRace, event, eventLocaleKey, slug }: Props) => {
 
 	const t = useTranslations('All');
@@ -41,7 +45,7 @@ const RaceTR: FunctionComponent<RaceRowTR> = ({ hasMultipleFeaturedEvents, title
 		var blankColumnCount = config.featuredSessions.length - 1;
 
 		return (
-			<tr className={`${collapsed ? "hidden" : ""} ${hasOccured ? "line-through text-gray-400" : ""}`}>
+			<tr className={`${STYLES.border} ${collapsed ? "hidden" : ""} ${hasOccured ? "line-through text-gray-400" : ""}`}>
 				<td className=""></td>
 				<td className="p-4">{t(titleKey)}</td>
 				<td className="text-right">
@@ -59,7 +63,7 @@ const RaceTR: FunctionComponent<RaceRowTR> = ({ hasMultipleFeaturedEvents, title
 		);
 	} else {
 		return (
-			<tr className={`${collapsed ? "hidden" : ""} ${hasOccured ? "line-through text-gray-400" : ""} ${!hasOccured && isFeaturedSession ? "font-bold" : ""} ${isNextRace && isFeaturedSession ? "text-yellow-600" : ""}`}>
+			<tr className={`${STYLES.border} ${collapsed ? "hidden" : ""} ${hasOccured ? "line-through text-gray-400" : ""} ${!hasOccured && isFeaturedSession ? "font-bold" : ""} ${isNextRace && isFeaturedSession ? "text-yellow-600" : ""}`}>
 				<td className=""></td>
 				<td className="p-4"><span className="hidden">{eventName}</span> {t(titleKey)}</td>
 				<td className="text-right md:text-left" headers={`date_header ${slug}-header`}>


### PR DESCRIPTION
Hello and thanks for the service, it's really useful!

I found myself struggling a bit to read the timetable of each race, so I put a border on each row to improve readability

From this
![Screenshot 2024-03-02 at 15 30 47](https://github.com/sportstimes/f1/assets/15871923/55669109-0641-4fbc-9044-661a82def6d9)

to this
![Screenshot 2024-03-02 at 15 31 21](https://github.com/sportstimes/f1/assets/15871923/0033d047-4aed-4b12-8d2e-4dceb6e8d2a5)

I hope you like the idea.
