### PR TITLE
Update Indycar [indycar-calendar / automated]

### DIFF
--- a/_db/indycar/2025.json
+++ b/_db/indycar/2025.json
@@ -69,7 +69,8 @@
       "sessions": {
         "practice1": "2025-05-09T13:30:00Z",
         "practice2": "2025-05-09T17:10:00Z",
-        "qualifying": "2025-05-09T20:20:00Z",
+        "qualifying": "2025-05-09T20:30:00Z",
+        "practice3": "2025-05-10T15:32:00Z",
         "race": "2025-05-10T20:30:00Z"
       },
       "tbc": false,
@@ -82,17 +83,18 @@
     {
       "name": "109th Running of the Indianapolis 500",
       "sessions": {
-        "practice1": "2025-05-13T13:00:00Z",
-        "practice2": "2025-05-13T17:00:00Z",
-        "practice3": "2025-05-14T14:00:00Z",
-        "p4": "2025-05-15T14:00:00Z",
-        "p5": "2025-05-16T16:00:00Z",
-        "p6": "2025-05-17T12:30:00Z",
+        "practice1": "2025-05-13T16:00:00Z",
+        "practice3": "2025-05-14T16:00:00Z",
+        "RopRefreshers": "2025-05-15T14:00:00Z",
+        "practice4": "2025-05-15T16:00:00Z",
+        "practice5": "2025-05-16T16:00:00Z",
+        "practice6": "2025-05-17T12:30:00Z",
         "qualifying": "2025-05-17T15:00:00Z",
-        "p7": "2025-05-18T16:00:00Z",
-        "p8": "2025-05-19T17:00:00Z",
-        "p9": "2025-05-23T15:00:00Z",
-        "race": "2025-05-25T14:00:00Z"
+        "practice7": "2025-05-18T17:00:00Z",
+        "qualifying2": "2025-05-18T20:00:00Z",
+        "practice8": "2025-05-19T17:00:00Z",
+        "practice9": "2025-05-23T15:00:00Z",
+        "race": "2025-05-25T16:30:00Z"
       },
       "tbc": false,
       "round": 6,
@@ -104,9 +106,10 @@
     {
       "name": "Chevrolet Detroit Grand Prix",
       "sessions": {
-        "practice1": "2025-05-30T19:00:00Z",
-        "practice2": "2025-05-31T13:10:00Z",
-        "qualifying": "2025-05-31T16:15:00Z",
+        "practice1": "2025-05-30T19:05:00Z",
+        "practice2": "2025-05-31T13:05:00Z",
+        "qualifying": "2025-05-31T16:00:00Z",
+        "practice3": "2025-06-01T13:32:00Z",
         "race": "2025-06-01T16:30:00Z"
       },
       "tbc": false,
@@ -119,11 +122,10 @@
     {
       "name": "Bommarito Automotive Group 500",
       "sessions": {
-        "practice3": "2025-06-14T21:45:00Z",
-        "practice1": "2025-06-14T23:45:00Z",
-        "practice2": "2025-06-15T01:00:00Z",
-        "qualifying": "2025-06-15T15:00:00Z",
-        "race": "2025-06-15T19:00:00Z"
+        "practice1": "2025-06-14T18:00:00Z",
+        "qualifying": "2025-06-14T21:30:00Z",
+        "practice2": "2025-06-15T00:15:00Z",
+        "race": "2025-06-16T00:00:00Z"
       },
       "tbc": false,
       "round": 8,
@@ -135,10 +137,11 @@
     {
       "name": "XPEL Grand Prix at Road America",
       "sessions": {
-        "practice1": "2025-06-20T21:00:00Z",
-        "practice2": "2025-06-21T15:10:00Z",
-        "qualifying": "2025-06-21T19:25:00Z",
-        "race": "2025-06-22T19:30:00Z"
+        "practice1": "2025-06-20T20:30:00Z",
+        "practice2": "2025-06-21T15:00:00Z",
+        "qualifying": "2025-06-21T18:30:00Z",
+        "warmup": "2025-06-22T14:00:00Z",
+        "race": "2025-06-22T17:30:00Z"
       },
       "tbc": false,
       "round": 9,
@@ -150,10 +153,11 @@
     {
       "name": "Honda Indy 200 at Mid-Ohio",
       "sessions": {
-        "practice1": "2025-07-04T19:05:00Z",
-        "practice2": "2025-07-05T13:45:00Z",
-        "qualifying": "2025-07-05T18:45:00Z",
-        "race": "2025-07-06T18:00:00Z"
+        "practice1": "2025-07-04T20:00:00Z",
+        "practice2": "2025-07-05T14:30:00Z",
+        "qualifying": "2025-07-05T18:30:00Z",
+        "warmup": "2025-07-06T13:30:00Z",
+        "race": "2025-07-06T17:00:00Z"
       },
       "tbc": false,
       "round": 10,
@@ -163,37 +167,40 @@
       "latitude": 0
     },
     {
-      "name": "Sukup INDYCAR Race Weekend Race 1",
+      "name": "Synk 275 powered by Sukup",
       "sessions": {
-        "practice1": "2025-07-11T20:30:00Z",
-        "qualifying": "2025-07-12T20:30:00Z",
+        "practice1": "2025-07-12T14:45:00Z",
+        "qualifying": "2025-07-12T17:30:00Z",
         "race": "2025-07-12T21:00:00Z"
       },
       "tbc": false,
       "round": 11,
-      "slug": "sukup-indycar-race-weekend-race-1",
-      "localeKey": "sukup-indycar-race-weekend-race-1",
+      "slug": "synk-275-powered-by-sukup",
+      "localeKey": "synk-275-powered-by-sukup",
       "longitude": 0,
       "latitude": 0
     },
     {
-      "name": "Sukup INDYCAR Race Weekend Race 2",
+      "name": "Farm to Finish 275",
       "sessions": {
-        "qualifying": "2025-07-12T15:15:00Z",
-        "race": "2025-07-13T18:00:00Z"
+        "qualifying": "2025-07-12T17:30:00Z",
+        "race": "2025-07-13T17:00:00Z"
       },
       "tbc": false,
       "round": 12,
-      "slug": "sukup-indycar-race-weekend-race-2",
-      "localeKey": "sukup-indycar-race-weekend-race-2",
+      "slug": "farm-to-finish-275",
+      "localeKey": "farm-to-finish-275",
       "longitude": 0,
       "latitude": 0
     },
     {
       "name": "Ontario Honda Dealers Indy Toronto",
       "sessions": {
-        "qualifying": "2025-07-19T18:50:00Z",
-        "race": "2025-07-20T18:00:00Z"
+        "practice1": "2025-07-18T19:00:00Z",
+        "practice2": "2025-07-19T14:30:00Z",
+        "qualifying": "2025-07-19T18:30:00Z",
+        "warmup": "2025-07-20T12:30:00Z",
+        "race": "2025-07-20T16:00:00Z"
       },
       "tbc": false,
       "round": 13,
@@ -203,26 +210,24 @@
       "latitude": 0
     },
     {
-      "name": "INDYCAR Grand Prix of Monterey",
+      "name": "Java House Grand Prix of Monterey",
       "sessions": {
-        "practice1": "2025-07-25T00:00:00Z",
-        "practice2": "2025-07-25T20:00:00Z",
-        "qualifying": "2025-07-26T21:15:00Z",
+        "practice1": "2025-07-25T21:00:00Z",
+        "practice2": "2025-07-26T15:30:00Z",
+        "qualifying": "2025-07-26T18:30:00Z",
+        "warmup": "2025-07-27T16:00:00Z",
         "race": "2025-07-27T19:00:00Z"
       },
       "tbc": false,
       "round": 14,
-      "slug": "indycar-grand-prix-of-monterey",
-      "localeKey": "indycar-grand-prix-of-monterey",
+      "slug": "java-house-grand-prix-of-monterey",
+      "localeKey": "java-house-grand-prix-of-monterey",
       "longitude": 0,
       "latitude": 0
     },
     {
       "name": "BITNILE.com Grand Prix of Portland",
       "sessions": {
-        "practice1": "2025-08-08T22:00:00Z",
-        "practice2": "2025-08-09T16:00:00Z",
-        "practice3": "2025-08-10T00:15:00Z",
         "race": "2025-08-10T19:00:00Z",
         "qualifying": "2025-08-10T19:30:00Z"
       },
@@ -236,8 +241,6 @@
     {
       "name": "Snap-on Milwaukee Mile 250",
       "sessions": {
-        "practice1": "2025-08-23T20:40:00Z",
-        "practice2": "2025-08-24T14:00:00Z",
         "qualifying": "2025-08-24T17:30:00Z",
         "race": "2025-08-24T18:00:00Z"
       },
@@ -249,15 +252,15 @@
       "latitude": 0
     },
     {
-      "name": "Big Machine Music City Grand Prix",
+      "name": "Borchetta Bourbon Music City Grand Prix",
       "sessions": {
         "qualifying": "2025-08-30T18:45:00Z",
         "race": "2025-08-31T18:30:00Z"
       },
       "tbc": false,
       "round": 17,
-      "slug": "big-machine-music-city-grand-prix",
-      "localeKey": "big-machine-music-city-grand-prix",
+      "slug": "borchetta-bourbon-music-city-grand-prix",
+      "localeKey": "borchetta-bourbon-music-city-grand-prix",
       "longitude": 0,
       "latitude": 0
     }


### PR DESCRIPTION
Generated by `indycar-calender`

Please contact in case of 🔥🏎🔥

---

Updated [indycar-calendar](https://github.com/maxgubler/indycar-calendar/commits/master/) to use a different endpoint, combine sessions when split across TV networks, and infer session from title. The previous data endpoint from foxsports was returning the wrong data structure for some later races. Also, the keys were not reliable, as the titles would change but the keys would remain -- so, title is more accurate. Also, handling cancelled sessions.