### PR TITLE
Add missing Las Vegas GP translations for zh-HK and ja locales

### DIFF
--- a/locales/ja/localization.json
+++ b/locales/ja/localization.json
@@ -72,7 +72,7 @@
       "qatar-grand-prix": "カタールGP",
       "miami-grand-prix": "マイアミGP",
       "chinese-grand-prix": "中国GP",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "ラスベガスGP"
     },
     "options": {
       "calendar": "開催日程をカレンダーに追加",

--- a/locales/zh-HK/localization.json
+++ b/locales/zh-HK/localization.json
@@ -72,7 +72,7 @@
       "qatar-grand-prix": "卡塔爾大獎賽",
       "miami-grand-prix": "邁阿密大獎賽",
       "chinese-grand-prix": "中國大獎賽",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "拉斯維加斯大獎賽"
     },
     "options": {
       "calendar": "在你的日曆中添加賽程信息",


### PR DESCRIPTION
## Description
- Add missing Traditional Chinese (zh-HK) and Japanese (ja) translations for Las Vegas Grand Prix
- Previously showed "Las Vegas Grand Prix" in English instead of localized text

## Changes
- **zh-HK**: `"Las Vegas Grand Prix"` → `"拉斯維加斯大獎賽"`
- **ja**: `"Las Vegas Grand Prix"` → `"ラスベガスGP"`
