### PR TITLE
Fix Cumulative Layout Shift on initial load

### DIFF
--- a/src/components/CTABar/CTABar.tsx
+++ b/src/components/CTABar/CTABar.tsx
@@ -14,6 +14,7 @@ const config = require(`/_db/${process.env.NEXT_PUBLIC_SITE_KEY}/config.json`);
 const CTABar = () => {
   const [supportsWebPush, setSupportsWebPush] = useState(false);
   const [isInstalled, setIsInstalled] = useState(false);
+  const [isHydrated, setIsHydrated] = useState(false);
   const t = useTranslations('All');
   const locale = useLocale();
 
@@ -30,7 +31,33 @@ const CTABar = () => {
       setSupportsWebPush(true);
       setIsInstalled(installed);
     }
+
+    setIsHydrated(true);
   }, []);
+
+  // Show skeleton buttons with fixed height while hydrating to prevent CLS
+  if (!isHydrated) {
+    return (
+      <div className="grid grid-col-1 md:flex pt-4 gap-3 gap-y-2">
+        <div className="h-12 grow">
+          <div className="bg-mid-green rounded-md shadow h-12 animate-pulse"></div>
+        </div>
+        {config.supportsEmailReminders > 0 && (
+          <div className="h-12 grow">
+            <div className="bg-mid-green rounded-md shadow h-12 animate-pulse"></div>
+          </div>
+        )}
+        {config.supportsWebPush > 0 && (
+          <div className="h-12">
+            <div className="bg-mid-green rounded-md shadow h-12 w-12 md:w-12 animate-pulse"></div>
+          </div>
+        )}
+        <div className="h-12 grow md:hidden">
+          <div className="bg-mid-green rounded-md shadow h-12 animate-pulse"></div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={`grid grid-col-1 md:flex pt-4 gap-3 gap-y-2`}>

--- a/src/components/Races/Races.tsx
+++ b/src/components/Races/Races.tsx
@@ -14,11 +14,43 @@ export interface Props {
 	locale?: string;
 }
 
+const RacesSkeleton = ({ count }: { count: number }) => {
+	return (
+		<div className="animate-pulse">
+			<table className="w-full">
+				<tbody>
+					{Array.from({ length: count }).map((_, index) => (
+						<tr key={index} className={index % 2 === 1 ? 'bg-row-gray' : ''}>
+							<td className="w-4 lg:w-8 p-4">
+								<div className="w-4 h-4 bg-gray-700 rounded"></div>
+							</td>
+							<td className="p-4">
+								<div className="h-5 bg-gray-700 rounded w-48"></div>
+							</td>
+							<td className="p-4 text-right md:text-left">
+								<div className="h-5 bg-gray-700 rounded w-16 ml-auto md:ml-0"></div>
+							</td>
+							<td className="p-4">
+								<div className="h-5 bg-gray-700 rounded w-14 ml-auto md:ml-0"></div>
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+};
+
 const Races = ({ year, races }: Props) => {
 	const t = useTranslations('All');
 	const title = t(`${process.env.NEXT_PUBLIC_SITE_KEY}.title`);
 
-	let {timezone, timeFormat, collapsePastRaces, updateCollapsePastRaces} = useUserContext();
+	let {timezone, timeFormat, collapsePastRaces, updateCollapsePastRaces, isHydrated} = useUserContext();
+
+	// Show skeleton while hydrating to prevent CLS
+	if (!isHydrated) {
+		return <RacesSkeleton count={Math.min(races.length, 8)} />;
+	}
 
 	//if (props.locale) locale = props.locale;
 

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -8,9 +8,14 @@ import Link from 'next/link';
 import SiteSelector from '../../components/SiteSelector/SiteSelector';
 import dynamic from 'next/dynamic';
 
+// Placeholder with fixed dimensions to prevent CLS
+const LanguageSelectorSkeleton = () => (
+  <div className="w-[120px] h-[30px] bg-gray-200 rounded-md animate-pulse"></div>
+);
+
 const LanguageSelector = dynamic(
   () => import('../../components/LanguageSelector/LanguageSelector'),
-  { ssr: false },
+  { ssr: false, loading: () => <LanguageSelectorSkeleton /> },
 );
 
 function TopBar() {


### PR DESCRIPTION
- Add isHydrated state to UserContext to track when localStorage values are loaded
- Show skeleton loader in Races component while hydrating to prevent timezone-related layout shifts
- Add skeleton loading state to CTABar while detecting PWA installation status
- Add loading placeholder to TopBar LanguageSelector dynamic import