### PR TITLE
Fix relative links in Footer navigation

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -184,9 +184,9 @@ const Footer = () => {
             </p>
 
             <p className="text-base text-gray-400 text-xsm px-2 md:px-0">
-              <Link href={`years`}>Years</Link>
+              <Link href={`/years`}>Years</Link>
               {' • '}
-              <Link href={`timezones`}>Timezones</Link>
+              <Link href={`/timezones`}>Timezones</Link>
 
               {config.trmnlPlugin && (
                 <>


### PR DESCRIPTION
## Summary
Fixed incorrect relative link paths in the Footer component by adding leading slashes to make them absolute paths.

## Changes
- Updated `Years` link from `years` to `/years`
- Updated `Timezones` link from `timezones` to `/timezones`

## Details
The links were using relative paths without leading slashes, which could cause routing issues depending on the current page location. By adding the leading slash, these links now correctly reference absolute paths from the root of the application, ensuring consistent navigation behavior regardless of where the user is in the app.

https://claude.ai/code/session_016HbSNmQfsfZEYkgAm3HSxy