### PR TITLE
Fix broken footer links on timezone pages

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -184,9 +184,9 @@ const Footer = () => {
             </p>
 
             <p className="text-base text-gray-400 text-xsm px-2 md:px-0">
-              <Link href={`years`}>Years</Link>
+              <Link href={`/years`}>Years</Link>
               {' • '}
-              <Link href={`timezones`}>Timezones</Link>
+              <Link href={`/timezones`}>Timezones</Link>
 
               {config.trmnlPlugin && (
                 <>


### PR DESCRIPTION
Use absolute paths (/years, /timezones) instead of relative paths so links resolve correctly on nested routes like /timezone/Europe-London.

https://claude.ai/code/session_016HbSNmQfsfZEYkgAm3HSxy