### PR TITLE
Fall back when the browser rejects the user's timezone

### DIFF
--- a/src/components/UserContext.tsx
+++ b/src/components/UserContext.tsx
@@ -33,6 +33,19 @@ export function useUserContext() {
     return useContext(UserContext);
 }
 
+// Older browsers (e.g. Firefox 115 ESR) ship an ICU snapshot that doesn't know
+// IANA zones added in later tzdb releases — e.g. America/Coyhaique (2024).
+// Using one of those zones with Intl.DateTimeFormat throws RangeError and
+// crashes the React tree. Probe the zone here so we can fall back gracefully.
+function isTimezoneSupportedByBrowser(tz: string): boolean {
+    try {
+        new Intl.DateTimeFormat(undefined, { timeZone: tz });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 type Props = {
     children: ReactNode;
 };
@@ -49,13 +62,25 @@ export function UserContextProvider({ children }: Props) {
         dayjs.extend(dayjstimezone);
 
         // Fetch the stored timezone, or guess it via dayjs and save it.
+        const fallbackTimezone = "Europe/London";
+        const normalize = (tz: string) => tz === "Europe/Kyiv" ? "Europe/Kiev" : tz;
+        const resolve = (tz: string) => {
+            const normalized = normalize(tz);
+            return isTimezoneSupportedByBrowser(normalized) ? normalized : fallbackTimezone;
+        };
+
         const storedTimezone = localStorage.getItem("timezone");
         if (storedTimezone) {
-            updateStateTimezone(storedTimezone === "Europe/Kyiv" ? "Europe/Kiev" : storedTimezone);
+            const resolved = resolve(storedTimezone);
+            updateStateTimezone(resolved);
+            if (resolved !== storedTimezone) {
+                localStorage.setItem("timezone", resolved);
+            }
         } else {
             const guessedTimezone = dayjs.tz.guess();
-            updateStateTimezone(guessedTimezone === "Europe/Kyiv" ? "Europe/Kiev" : guessedTimezone);
-            localStorage.setItem("timezone", guessedTimezone);
+            const resolved = resolve(guessedTimezone);
+            updateStateTimezone(resolved);
+            localStorage.setItem("timezone", resolved);
         }
 
         // Fetch the stored time format (12hr/24hr)
@@ -93,7 +118,11 @@ export function UserContextProvider({ children }: Props) {
         if(timezone == "Europe/Kyiv"){
             timezone = "Europe/Kiev";
         }
-        
+
+        if (!isTimezoneSupportedByBrowser(timezone)) {
+            timezone = "Europe/London";
+        }
+
         updateStateTimezone(timezone);
         localStorage.setItem("timezone", timezone);
     };


### PR DESCRIPTION
## Summary

- Older browsers (notably Firefox 115 ESR) ship an ICU snapshot that doesn't recognise IANA zones added in newer tzdb releases. When `dayjs.tz.guess()` returns one of these (e.g. `America/Coyhaique`, added in 2024), the first `.tz(zone).format(...)` call throws `RangeError: invalid time zone in DateTimeFormat()` from `Intl.DateTimeFormat` and crashes the React tree — users saw a brief flash of real content followed by the error overlay.
- `UserContext` now probes the resolved timezone via `Intl.DateTimeFormat` and falls back to `Europe/London` (the existing default) if the browser rejects it. The probe runs on the localStorage-cached value, the `dayjs.tz.guess()` result, and any `updateTimezone` call.
- A bad value already cached in `localStorage` is rewritten with the fallback so it self-heals on the next load.
- The existing `Europe/Kyiv → Europe/Kiev` mapping is preserved and applied before the probe.

Reported in the issue thread — error logged on Firefox 115 was `Uncaught RangeError: invalid time zone in DateTimeFormat(): America/Coyhaique`.

## Test plan

- [ ] Manually load the site in a browser whose ICU does not know `America/Coyhaique` (e.g. Firefox 115) and confirm the page renders instead of crashing.
- [ ] Set `localStorage.timezone = "America/Coyhaique"` in such a browser, reload, and confirm it falls back to `Europe/London` and overwrites the bad value.
- [ ] In a modern browser, confirm normal zones (`Europe/London`, `Europe/Kiev`, the auto-guessed local zone) still work and that the picker continues to operate.
- [ ] Confirm the `Europe/Kyiv → Europe/Kiev` mapping still applies on first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)