### PR TITLE
Update F2 Hungaroring qualifying session start time

### DIFF
--- a/_db/f2/2026.json
+++ b/_db/f2/2026.json
@@ -130,7 +130,7 @@
       "localeKey": "hungarian",
       "sessions": {
         "practice": "2026-07-24T09:05:00Z",
-        "qualifying": "2026-07-24T13:55:00Z",
+        "qualifying": "2026-07-24T14:05:00Z",
         "sprint": "2026-07-25T12:15:00Z",
         "feature": "2026-07-26T09:25:00Z"
       }


### PR DESCRIPTION
Source: https://hungaroring.hu/site/hu/versenyek/2026-formula-1-aws-magyar-nagydij/idoterv-2026-07-24