### PR TITLE
Add TBC 2026 Malaysian Grand Prix at Sepang

### DIFF
--- a/_db/f1/2026.json
+++ b/_db/f1/2026.json
@@ -241,11 +241,28 @@
       }
     },
     {
+      "name": "Malaysian",
+      "location": "Sepang",
+      "latitude": 2.760278,
+      "longitude": 101.738056,
+      "round": 16,
+      "slug": "malaysian-grand-prix",
+      "localeKey": "malaysian-grand-prix",
+      "tbc": true,
+      "sessions": {
+        "fp1": "2026-10-02T02:00:00Z",
+        "fp2": "2026-10-02T06:00:00Z",
+        "fp3": "2026-10-03T06:00:00Z",
+        "qualifying": "2026-10-03T09:00:00Z",
+        "gp": "2026-10-04T07:00:00Z"
+      }
+    },
+    {
       "name": "Singapore",
       "location": "Singapore",
       "latitude": 1.2857,
       "longitude": 103.8575,
-      "round": 16,
+      "round": 17,
       "slug": "singapore-grand-prix",
       "localeKey": "singapore-grand-prix",
       "sessions": {
@@ -261,7 +278,7 @@
       "location": "Austin",
       "latitude": 30.1328,
       "longitude": -97.6411,
-      "round": 17,
+      "round": 18,
       "slug": "us-grand-prix",
       "localeKey": "us-grand-prix",
       "sessions": {
@@ -277,7 +294,7 @@
       "location": "Mexico City",
       "latitude": 19.4028,
       "longitude": -99.0986,
-      "round": 18,
+      "round": 19,
       "slug": "mexican-grand-prix",
       "localeKey": "mexico-grand-prix",
       "sessions": {
@@ -293,7 +310,7 @@
       "location": "Sao Paulo",
       "latitude": -23.7014,
       "longitude": -46.6969,
-      "round": 19,
+      "round": 20,
       "slug": "brazilian-grand-prix",
       "localeKey": "brazilian-grand-prix",
       "sessions": {
@@ -309,7 +326,7 @@
       "location": "Las Vegas",
       "latitude": 36.166747,
       "longitude": -115.148708,
-      "round": 20,
+      "round": 21,
       "slug": "las-vegas-grand-prix",
       "localeKey": "las-vegas-grand-prix",
       "sessions": {
@@ -325,7 +342,7 @@
       "location": "Doha",
       "latitude": 25.490292,
       "longitude": 51.45303,
-      "round": 21,
+      "round": 22,
       "slug": "qatar-grand-prix",
       "localeKey": "qatar-grand-prix",
       "sessions": {
@@ -341,7 +358,7 @@
       "location": "Yas Marina",
       "latitude": 24.4821,
       "longitude": 54.3482,
-      "round": 22,
+      "round": 23,
       "slug": "abu-dhabi-grand-prix",
       "localeKey": "abu-dhabi-grand-prix",
       "sessions": {

--- a/_db/f1/2026.json
+++ b/_db/f1/2026.json
@@ -241,13 +241,13 @@
       }
     },
     {
-      "name": "Malaysian",
+      "name": "Bahrain Grand Prix (Malaysia)",
       "location": "Sepang",
       "latitude": 2.760278,
       "longitude": 101.738056,
       "round": 16,
-      "slug": "malaysian-grand-prix",
-      "localeKey": "malaysian-grand-prix",
+      "slug": "bahrain-malaysia-grand-prix",
+      "localeKey": "bahrain-malaysia-grand-prix",
       "tbc": true,
       "sessions": {
         "fp1": "2026-10-02T02:00:00Z",

--- a/locales/ar/localization.json
+++ b/locales/ar/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "جائزة الصين الكبري",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "جائزة ماليزيا الكبري"
+      "bahrain-malaysia-grand-prix": "جائزة البحرين الكبري (ماليزيا)"
     },
     "options": {
       "calendar": "اضف مواعيد السباقات الي تقويمك",

--- a/locales/ar/localization.json
+++ b/locales/ar/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "جائزة الصين الكبري",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "جائزة ماليزيا الكبري"
     },
     "options": {
       "calendar": "اضف مواعيد السباقات الي تقويمك",

--- a/locales/cs/localization.json
+++ b/locales/cs/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Velká cena Číny",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Velká cena Malajsie"
     },
     "options": {
       "calendar": "Přidejte si termíny a časy závodů do svého kalendáře.",

--- a/locales/cs/localization.json
+++ b/locales/cs/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Velká cena Číny",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Velká cena Malajsie"
+      "bahrain-malaysia-grand-prix": "Velká cena Bahrajnu (Malajsie)"
     },
     "options": {
       "calendar": "Přidejte si termíny a časy závodů do svého kalendáře.",

--- a/locales/da/localization.json
+++ b/locales/da/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miamis Grand Prix",
       "chinese-grand-prix": "Kinas Grand Prix",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Malaysias Grand Prix"
+      "bahrain-malaysia-grand-prix": "Bahrains Grand Prix (Malaysia)"
     },
     "options": {
       "calendar": "Tilføj løbsdatoer & tider til din kalender",

--- a/locales/da/localization.json
+++ b/locales/da/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatars Grand Prix",
       "miami-grand-prix": "Miamis Grand Prix",
       "chinese-grand-prix": "Kinas Grand Prix",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Malaysias Grand Prix"
     },
     "options": {
       "calendar": "Tilføj løbsdatoer & tider til din kalender",

--- a/locales/de/localization.json
+++ b/locales/de/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Großer Preis von China",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Großer Preis von Malaysia"
     },
     "options": {
       "calendar": "Füge diese Renndaten - und Zeiten deinem Kalender hinzu",

--- a/locales/de/localization.json
+++ b/locales/de/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Großer Preis von China",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Großer Preis von Malaysia"
+      "bahrain-malaysia-grand-prix": "Großer Preis von Bahrain (Malaysia)"
     },
     "options": {
       "calendar": "Füge diese Renndaten - und Zeiten deinem Kalender hinzu",

--- a/locales/el/localization.json
+++ b/locales/el/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Γκραν Πρι Μαϊάμι",
       "chinese-grand-prix": "Γκραν Πρι Κίνας",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Γκραν Πρι Μαλαισίας"
+      "bahrain-malaysia-grand-prix": "Γκραν Πρι Μπαχρέιν (Μαλαισία)"
     },
     "options": {
       "calendar": "Προσθήκη ημερομηνιών και ωρών αγώνων στο Ημερολόγιό σας",

--- a/locales/el/localization.json
+++ b/locales/el/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Γκραν Πρι Κατάρ",
       "miami-grand-prix": "Γκραν Πρι Μαϊάμι",
       "chinese-grand-prix": "Γκραν Πρι Κίνας",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Γκραν Πρι Μαλαισίας"
     },
     "options": {
       "calendar": "Προσθήκη ημερομηνιών και ωρών αγώνων στο Ημερολόγιό σας",

--- a/locales/en/localization.json
+++ b/locales/en/localization.json
@@ -100,7 +100,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Chinese Grand Prix",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Malaysian Grand Prix"
+      "bahrain-malaysia-grand-prix": "Bahrain Grand Prix (Malaysia)"
     },
     "options": {
       "calendar": "Add race dates & times to your Calendar",

--- a/locales/en/localization.json
+++ b/locales/en/localization.json
@@ -99,7 +99,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Chinese Grand Prix",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Malaysian Grand Prix"
     },
     "options": {
       "calendar": "Add race dates & times to your Calendar",

--- a/locales/es/localization.json
+++ b/locales/es/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Gran Premio de Catar",
       "miami-grand-prix": "Gran Premio de Miami",
       "chinese-grand-prix": "Gran Premio de China",
-      "las-vegas-grand-prix": "Gran Premio de Las Vegas"
+      "las-vegas-grand-prix": "Gran Premio de Las Vegas",
+      "malaysian-grand-prix": "Gran Premio de Malasia"
     },
     "options": {
       "calendar": "Agregar las fechas y horarios de estas carreras a tu calendario",

--- a/locales/es/localization.json
+++ b/locales/es/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Gran Premio de Miami",
       "chinese-grand-prix": "Gran Premio de China",
       "las-vegas-grand-prix": "Gran Premio de Las Vegas",
-      "malaysian-grand-prix": "Gran Premio de Malasia"
+      "bahrain-malaysia-grand-prix": "Gran Premio de Baréin (Malasia)"
     },
     "options": {
       "calendar": "Agregar las fechas y horarios de estas carreras a tu calendario",

--- a/locales/fi/localization.json
+++ b/locales/fi/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Kiinan GP",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Malesian GP"
+      "bahrain-malaysia-grand-prix": "Bahrainin GP (Malesia)"
     },
     "options": {
       "calendar": "Lisää osakilpailujen aikataulut kalenteriin",

--- a/locales/fi/localization.json
+++ b/locales/fi/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Kiinan GP",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Malesian GP"
     },
     "options": {
       "calendar": "Lisää osakilpailujen aikataulut kalenteriin",

--- a/locales/fr/localization.json
+++ b/locales/fr/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Grand Prix de Chine",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Grand Prix de Malaisie"
+      "bahrain-malaysia-grand-prix": "Grand Prix de Bahrein (Malaisie)"
     },
     "options": {
       "calendar": "Ajouter ces dates et horaires de Grand Prix à votre calendrier.",

--- a/locales/fr/localization.json
+++ b/locales/fr/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Grand Prix de Chine",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Grand Prix de Malaisie"
     },
     "options": {
       "calendar": "Ajouter ces dates et horaires de Grand Prix à votre calendrier.",

--- a/locales/hr/localization.json
+++ b/locales/hr/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Velika nagrada Kine",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Velika nagrada Malezije"
+      "bahrain-malaysia-grand-prix": "Velika nagrada Bahreina (Malezija)"
     },
     "options": {
       "calendar": "Dodajte ove datume utrka na vaš kalendar",

--- a/locales/hr/localization.json
+++ b/locales/hr/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Velika nagrada Kine",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Velika nagrada Malezije"
     },
     "options": {
       "calendar": "Dodajte ove datume utrka na vaš kalendar",

--- a/locales/hu/localization.json
+++ b/locales/hu/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Kínai Nagydíj",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Maláj Nagydíj"
+      "bahrain-malaysia-grand-prix": "Bahreini Nagydíj (Malajzia)"
     },
     "options": {
       "calendar": "Futam időpontok hozzáadása a saját Naptárhoz",

--- a/locales/hu/localization.json
+++ b/locales/hu/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Kínai Nagydíj",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Maláj Nagydíj"
     },
     "options": {
       "calendar": "Futam időpontok hozzáadása a saját Naptárhoz",

--- a/locales/id/localization.json
+++ b/locales/id/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Grand Prix Miami",
       "chinese-grand-prix": "Grand Prix Tiongkok",
       "las-vegas-grand-prix": "Grand Prix Las Vegas ",
-      "malaysian-grand-prix": "Grand Prix Malaysia"
+      "bahrain-malaysia-grand-prix": "Grand Prix Bahrain (Malaysia)"
     },
     "options": {
       "calendar": "Tambahkan tanggal &amp; balapan ke Kalender Anda",

--- a/locales/id/localization.json
+++ b/locales/id/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Grand Prix Qatar",
       "miami-grand-prix": "Grand Prix Miami",
       "chinese-grand-prix": "Grand Prix Tiongkok",
-      "las-vegas-grand-prix": "Grand Prix Las Vegas "
+      "las-vegas-grand-prix": "Grand Prix Las Vegas ",
+      "malaysian-grand-prix": "Grand Prix Malaysia"
     },
     "options": {
       "calendar": "Tambahkan tanggal &amp; balapan ke Kalender Anda",

--- a/locales/it/localization.json
+++ b/locales/it/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Gran Premio del Qatar",
       "miami-grand-prix": "Gran Premio di Miami",
       "chinese-grand-prix": "Gran Premio di Cina",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Gran Premio della Malesia"
     },
     "options": {
       "calendar": "Aggiungi queste date e orari di gara al tuo calendario",

--- a/locales/it/localization.json
+++ b/locales/it/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Gran Premio di Miami",
       "chinese-grand-prix": "Gran Premio di Cina",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Gran Premio della Malesia"
+      "bahrain-malaysia-grand-prix": "Gran Premio del Bahrein (Malesia)"
     },
     "options": {
       "calendar": "Aggiungi queste date e orari di gara al tuo calendario",

--- a/locales/ja/localization.json
+++ b/locales/ja/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "マイアミGP",
       "chinese-grand-prix": "中国GP",
       "las-vegas-grand-prix": "ラスベガスGP",
-      "malaysian-grand-prix": "マレーシアGP"
+      "bahrain-malaysia-grand-prix": "バーレーンGP (マレーシア)"
     },
     "options": {
       "calendar": "開催日程をカレンダーに追加",

--- a/locales/ja/localization.json
+++ b/locales/ja/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "カタールGP",
       "miami-grand-prix": "マイアミGP",
       "chinese-grand-prix": "中国GP",
-      "las-vegas-grand-prix": "ラスベガスGP"
+      "las-vegas-grand-prix": "ラスベガスGP",
+      "malaysian-grand-prix": "マレーシアGP"
     },
     "options": {
       "calendar": "開催日程をカレンダーに追加",

--- a/locales/lv/localization.json
+++ b/locales/lv/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Ķīnas \"Grand Prix\"",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Malaizijas \"Grand Prix\""
+      "bahrain-malaysia-grand-prix": "Bahreinas \"Grand Prix\" (Malaizija)"
     },
     "options": {
       "calendar": "Pievienot sacīkšu datumus un laikus jūsu kalendāram",

--- a/locales/lv/localization.json
+++ b/locales/lv/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Ķīnas \"Grand Prix\"",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Malaizijas \"Grand Prix\""
     },
     "options": {
       "calendar": "Pievienot sacīkšu datumus un laikus jūsu kalendāram",

--- a/locales/nl/localization.json
+++ b/locales/nl/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Grand Prix van Qatar",
       "miami-grand-prix": "Grand Prix van Miami",
       "chinese-grand-prix": "Grand Prix van China",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Grand Prix van Maleisië"
     },
     "options": {
       "calendar": "Voeg deze race datums en starttijden toe aan je agenda",

--- a/locales/nl/localization.json
+++ b/locales/nl/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Grand Prix van Miami",
       "chinese-grand-prix": "Grand Prix van China",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Grand Prix van Maleisië"
+      "bahrain-malaysia-grand-prix": "Grand Prix van Bahrein (Maleisië)"
     },
     "options": {
       "calendar": "Voeg deze race datums en starttijden toe aan je agenda",

--- a/locales/no/localization.json
+++ b/locales/no/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Kinas Grand Prix",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Malaysias Grand Prix"
+      "bahrain-malaysia-grand-prix": "Bahrains Grand Prix (Malaysia)"
     },
     "options": {
       "calendar": "Legg til disse race-datoene og tidspunkt til din kalender",

--- a/locales/no/localization.json
+++ b/locales/no/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Kinas Grand Prix",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Malaysias Grand Prix"
     },
     "options": {
       "calendar": "Legg til disse race-datoene og tidspunkt til din kalender",

--- a/locales/pl/localization.json
+++ b/locales/pl/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Grand Prix Miami",
       "chinese-grand-prix": "Grand Prix Chin",
       "las-vegas-grand-prix": "Grand Prix Las Vegas",
-      "malaysian-grand-prix": "Grand Prix Malezji"
+      "bahrain-malaysia-grand-prix": "Grand Prix Bahrajnu (Malezja)"
     },
     "options": {
       "calendar": "Dodaj daty wyścigów do Twojego Kalendarza",

--- a/locales/pl/localization.json
+++ b/locales/pl/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Grand Prix Kataru",
       "miami-grand-prix": "Grand Prix Miami",
       "chinese-grand-prix": "Grand Prix Chin",
-      "las-vegas-grand-prix": "Grand Prix Las Vegas"
+      "las-vegas-grand-prix": "Grand Prix Las Vegas",
+      "malaysian-grand-prix": "Grand Prix Malezji"
     },
     "options": {
       "calendar": "Dodaj daty wyścigów do Twojego Kalendarza",

--- a/locales/pt-BR/localization.json
+++ b/locales/pt-BR/localization.json
@@ -98,7 +98,8 @@
       "qatar-grand-prix": "GP do Catar",
       "miami-grand-prix": "GP de Miami",
       "chinese-grand-prix": "GP da China",
-      "las-vegas-grand-prix": "GP de Las Vegas"
+      "las-vegas-grand-prix": "GP de Las Vegas",
+      "malaysian-grand-prix": "GP da Malásia"
     },
     "options": {
       "calendar": "Adicione essas datas e horários da corrida ao seu Calendário",

--- a/locales/pt-BR/localization.json
+++ b/locales/pt-BR/localization.json
@@ -99,7 +99,7 @@
       "miami-grand-prix": "GP de Miami",
       "chinese-grand-prix": "GP da China",
       "las-vegas-grand-prix": "GP de Las Vegas",
-      "malaysian-grand-prix": "GP da Malásia"
+      "bahrain-malaysia-grand-prix": "GP do Bahrein (Malásia)"
     },
     "options": {
       "calendar": "Adicione essas datas e horários da corrida ao seu Calendário",

--- a/locales/pt/localization.json
+++ b/locales/pt/localization.json
@@ -99,7 +99,7 @@
       "miami-grand-prix": "Grande Prémio de Miami",
       "chinese-grand-prix": "Grande Prémio da China",
       "las-vegas-grand-prix": "Grande Prémio de Las Vegas",
-      "malaysian-grand-prix": "Grande Prémio da Malásia"
+      "bahrain-malaysia-grand-prix": "Grande Prémio do Bahrain (Malásia)"
     },
     "options": {
       "calendar": "Adicione as datas e horas das corridas ao seu Calendário",

--- a/locales/pt/localization.json
+++ b/locales/pt/localization.json
@@ -98,7 +98,8 @@
       "qatar-grand-prix": "Grande Prémio do Catar",
       "miami-grand-prix": "Grande Prémio de Miami",
       "chinese-grand-prix": "Grande Prémio da China",
-      "las-vegas-grand-prix": "Grande Prémio de Las Vegas"
+      "las-vegas-grand-prix": "Grande Prémio de Las Vegas",
+      "malaysian-grand-prix": "Grande Prémio da Malásia"
     },
     "options": {
       "calendar": "Adicione as datas e horas das corridas ao seu Calendário",

--- a/locales/ro/localization.json
+++ b/locales/ro/localization.json
@@ -71,7 +71,8 @@
       "qatar-grand-prix": "Marele Premiu al Qatarului",
       "miami-grand-prix": "Marele Premiu din Miami",
       "chinese-grand-prix": "Marele Premiu al Chinei",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Marele Premiu al Malaeziei"
     },
     "options": {
       "calendar": "Adaugă data și ora curselor în Calendar",

--- a/locales/ro/localization.json
+++ b/locales/ro/localization.json
@@ -72,7 +72,7 @@
       "miami-grand-prix": "Marele Premiu din Miami",
       "chinese-grand-prix": "Marele Premiu al Chinei",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Marele Premiu al Malaeziei"
+      "bahrain-malaysia-grand-prix": "Marele Premiu al Bahrainului (Malaezia)"
     },
     "options": {
       "calendar": "Adaugă data și ora curselor în Calendar",

--- a/locales/ru/localization.json
+++ b/locales/ru/localization.json
@@ -99,6 +99,7 @@
       "miami-grand-prix": "Гран-при Майами",
       "chinese-grand-prix": "Гран-при Китая",
       "las-vegas-grand-prix": "Гран-при Лас-Вегаса",
+      "malaysian-grand-prix": "Гран-при Малайзии",
       "barcelona-catalunya-grand-prix": "Гран-при Барселоны-Каталонии"
     },
     "options": {

--- a/locales/ru/localization.json
+++ b/locales/ru/localization.json
@@ -99,7 +99,7 @@
       "miami-grand-prix": "Гран-при Майами",
       "chinese-grand-prix": "Гран-при Китая",
       "las-vegas-grand-prix": "Гран-при Лас-Вегаса",
-      "malaysian-grand-prix": "Гран-при Малайзии",
+      "bahrain-malaysia-grand-prix": "Гран-при Бахрейна (Малайзия)",
       "barcelona-catalunya-grand-prix": "Гран-при Барселоны-Каталонии"
     },
     "options": {

--- a/locales/sk/localization.json
+++ b/locales/sk/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Veľká cena Miami",
       "chinese-grand-prix": "Veľká cena Číny",
       "las-vegas-grand-prix": "Veľká cena Las Vegas",
-      "malaysian-grand-prix": "Veľká cena Malajzie"
+      "bahrain-malaysia-grand-prix": "Veľká cena Bahrainu (Malajzia)"
     },
     "options": {
       "calendar": "Pridať čas a dátum pretekov do vášho kalendára",

--- a/locales/sk/localization.json
+++ b/locales/sk/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Veľká cena Kataru",
       "miami-grand-prix": "Veľká cena Miami",
       "chinese-grand-prix": "Veľká cena Číny",
-      "las-vegas-grand-prix": "Veľká cena Las Vegas"
+      "las-vegas-grand-prix": "Veľká cena Las Vegas",
+      "malaysian-grand-prix": "Veľká cena Malajzie"
     },
     "options": {
       "calendar": "Pridať čas a dátum pretekov do vášho kalendára",

--- a/locales/sl/localization.json
+++ b/locales/sl/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "VN Kitajske",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "VN Malezije"
     },
     "options": {
       "calendar": "Dodaj te datume in čase dirk v svoj koledar",

--- a/locales/sl/localization.json
+++ b/locales/sl/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "VN Kitajske",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "VN Malezije"
+      "bahrain-malaysia-grand-prix": "VN Bahraina (Malezija)"
     },
     "options": {
       "calendar": "Dodaj te datume in čase dirk v svoj koledar",

--- a/locales/sq/localization.json
+++ b/locales/sq/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Çmimi i Madh i Kinës",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Çmimi i Madh i Malajzisë"
+      "bahrain-malaysia-grand-prix": "Çmimi i Madh i Bahrain (Malajzia)"
     },
     "options": {
       "calendar": "Shtoni oraret e këtyre garave në kalendarin tuaj",

--- a/locales/sq/localization.json
+++ b/locales/sq/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "Çmimi i Madh i Kinës",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Çmimi i Madh i Malajzisë"
     },
     "options": {
       "calendar": "Shtoni oraret e këtyre garave në kalendarin tuaj",

--- a/locales/sr-Cyrl/localization.json
+++ b/locales/sr-Cyrl/localization.json
@@ -98,7 +98,8 @@
       "qatar-grand-prix": "Велика награда Катара",
       "miami-grand-prix": "Велика награда Мајамија",
       "chinese-grand-prix": "Велика награда Кине",
-      "las-vegas-grand-prix": "Велика награда Лас Вегаса"
+      "las-vegas-grand-prix": "Велика награда Лас Вегаса",
+      "malaysian-grand-prix": "Велика награда Малезије"
     },
     "options": {
       "calendar": "Додај дане и времена трка у календар",

--- a/locales/sr-Cyrl/localization.json
+++ b/locales/sr-Cyrl/localization.json
@@ -99,7 +99,7 @@
       "miami-grand-prix": "Велика награда Мајамија",
       "chinese-grand-prix": "Велика награда Кине",
       "las-vegas-grand-prix": "Велика награда Лас Вегаса",
-      "malaysian-grand-prix": "Велика награда Малезије"
+      "bahrain-malaysia-grand-prix": "Велика награда Бахреина (Малезија)"
     },
     "options": {
       "calendar": "Додај дане и времена трка у календар",

--- a/locales/sr/localization.json
+++ b/locales/sr/localization.json
@@ -99,7 +99,7 @@
       "miami-grand-prix": "Velika nagrada Majamija",
       "chinese-grand-prix": "Velika nagrada Kine",
       "las-vegas-grand-prix": "Velika nagrada Las Vegasa",
-      "malaysian-grand-prix": "Velika nagrada Malezije"
+      "bahrain-malaysia-grand-prix": "Velika nagrada Bahreina (Malezija)"
     },
     "options": {
       "calendar": "Dodaj dane i vremena trka u kalendar",

--- a/locales/sr/localization.json
+++ b/locales/sr/localization.json
@@ -98,7 +98,8 @@
       "qatar-grand-prix": "Velika nagrada Katara",
       "miami-grand-prix": "Velika nagrada Majamija",
       "chinese-grand-prix": "Velika nagrada Kine",
-      "las-vegas-grand-prix": "Velika nagrada Las Vegasa"
+      "las-vegas-grand-prix": "Velika nagrada Las Vegasa",
+      "malaysian-grand-prix": "Velika nagrada Malezije"
     },
     "options": {
       "calendar": "Dodaj dane i vremena trka u kalendar",

--- a/locales/sv/localization.json
+++ b/locales/sv/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatars Grand Prix",
       "miami-grand-prix": "Miamis Grand Prix",
       "chinese-grand-prix": "Kinas Grand Prix",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "Malaysias Grand Prix"
     },
     "options": {
       "calendar": "Lägg till racetider och datum till din kalender",

--- a/locales/sv/localization.json
+++ b/locales/sv/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miamis Grand Prix",
       "chinese-grand-prix": "Kinas Grand Prix",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "Malaysias Grand Prix"
+      "bahrain-malaysia-grand-prix": "Bahrains Grand Prix (Malaysia)"
     },
     "options": {
       "calendar": "Lägg till racetider och datum till din kalender",

--- a/locales/ta/localization.json
+++ b/locales/ta/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Qatar Grand Prix",
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "சீனா பந்தயம்",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix",
+      "malaysian-grand-prix": "மலேசியப் பந்தயம்"
     },
     "options": {
       "calendar": "Add race dates & times to your Calendar",

--- a/locales/ta/localization.json
+++ b/locales/ta/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix",
       "chinese-grand-prix": "சீனா பந்தயம்",
       "las-vegas-grand-prix": "Las Vegas Grand Prix",
-      "malaysian-grand-prix": "மலேசியப் பந்தயம்"
+      "bahrain-malaysia-grand-prix": "பஹ்ரைன் பந்தயம் (மலேசியா)"
     },
     "options": {
       "calendar": "Add race dates & times to your Calendar",

--- a/locales/tr/localization.json
+++ b/locales/tr/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Katar Grand Prix'si",
       "miami-grand-prix": "Miami Grand Prix'si",
       "chinese-grand-prix": "Çin Grand Prix'si",
-      "las-vegas-grand-prix": "Las Vegas Grand Prix'si"
+      "las-vegas-grand-prix": "Las Vegas Grand Prix'si",
+      "malaysian-grand-prix": "Malezya Grand Prix'si"
     },
     "options": {
       "calendar": "Yarış programını kendi takviminize ekleyin",

--- a/locales/tr/localization.json
+++ b/locales/tr/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Miami Grand Prix'si",
       "chinese-grand-prix": "Çin Grand Prix'si",
       "las-vegas-grand-prix": "Las Vegas Grand Prix'si",
-      "malaysian-grand-prix": "Malezya Grand Prix'si"
+      "bahrain-malaysia-grand-prix": "Bahreyn Grand Prix'si (Malezya)"
     },
     "options": {
       "calendar": "Yarış programını kendi takviminize ekleyin",

--- a/locales/uk/localization.json
+++ b/locales/uk/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "Гран-прі Маямі",
       "chinese-grand-prix": "Гран-прі Китаю",
       "las-vegas-grand-prix": "Гран-прі Лас-Вегаса",
-      "malaysian-grand-prix": "Гран-прі Малайзії"
+      "bahrain-malaysia-grand-prix": "Гран-прі Бахрейну (Малайзія)"
     },
     "options": {
       "calendar": "Додати розклад гонок до календаря",

--- a/locales/uk/localization.json
+++ b/locales/uk/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "Гран-прі Катару",
       "miami-grand-prix": "Гран-прі Маямі",
       "chinese-grand-prix": "Гран-прі Китаю",
-      "las-vegas-grand-prix": "Гран-прі Лас-Вегаса"
+      "las-vegas-grand-prix": "Гран-прі Лас-Вегаса",
+      "malaysian-grand-prix": "Гран-прі Малайзії"
     },
     "options": {
       "calendar": "Додати розклад гонок до календаря",

--- a/locales/zh-HK/localization.json
+++ b/locales/zh-HK/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "卡塔爾大獎賽",
       "miami-grand-prix": "邁阿密大獎賽",
       "chinese-grand-prix": "中國大獎賽",
-      "las-vegas-grand-prix": "拉斯維加斯大獎賽"
+      "las-vegas-grand-prix": "拉斯維加斯大獎賽",
+      "malaysian-grand-prix": "馬來西亞大獎賽"
     },
     "options": {
       "calendar": "在你的日曆中添加賽程信息",

--- a/locales/zh-HK/localization.json
+++ b/locales/zh-HK/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "邁阿密大獎賽",
       "chinese-grand-prix": "中國大獎賽",
       "las-vegas-grand-prix": "拉斯維加斯大獎賽",
-      "malaysian-grand-prix": "馬來西亞大獎賽"
+      "bahrain-malaysia-grand-prix": "巴林大獎賽 (馬來西亞)"
     },
     "options": {
       "calendar": "在你的日曆中添加賽程信息",

--- a/locales/zh/localization.json
+++ b/locales/zh/localization.json
@@ -72,7 +72,8 @@
       "qatar-grand-prix": "卡塔尔大奖赛",
       "miami-grand-prix": "迈阿密大奖赛",
       "chinese-grand-prix": "中国大奖赛",
-      "las-vegas-grand-prix": "拉斯维加斯大奖赛"
+      "las-vegas-grand-prix": "拉斯维加斯大奖赛",
+      "malaysian-grand-prix": "马来西亚大奖赛"
     },
     "options": {
       "calendar": "在你的日历App中添加赛程信息",

--- a/locales/zh/localization.json
+++ b/locales/zh/localization.json
@@ -73,7 +73,7 @@
       "miami-grand-prix": "迈阿密大奖赛",
       "chinese-grand-prix": "中国大奖赛",
       "las-vegas-grand-prix": "拉斯维加斯大奖赛",
-      "malaysian-grand-prix": "马来西亚大奖赛"
+      "bahrain-malaysia-grand-prix": "巴林大奖赛 (马来西亚)"
     },
     "options": {
       "calendar": "在你的日历App中添加赛程信息",


### PR DESCRIPTION
Adds a provisional round 16 for the Malaysian Grand Prix at Sepang on
2-4 October 2026, marked as TBC, and renumbers the following rounds.
Session times are estimated from previous Sepang race weekends (local
UTC+8). Adds the malaysian-grand-prix race name to all locales.